### PR TITLE
Consider Run default command for saved aliases too

### DIFF
--- a/VisualStudio/CommandFactory.cs
+++ b/VisualStudio/CommandFactory.cs
@@ -84,11 +84,20 @@ namespace VisualStudio
                     // It's a saved command => the first argument should be the command name
                     var savedCommandName = savedCommandArgs.FirstOrDefault();
 
-                    if (!string.IsNullOrEmpty(savedCommandName) && factories.TryGetValue(savedCommandName, out factory))
+                    if (!string.IsNullOrEmpty(savedCommandName))
                     {
-                        // Restore the saved args
-                        args = ImmutableArray.Create(savedCommandArgs.Skip(1).ToArray());
-                        command = savedCommandName;
+                        if (factories.TryGetValue(savedCommandName, out factory))
+                        {
+                            // Restore the saved args
+                            args = ImmutableArray.Create(savedCommandArgs.Skip(1).ToArray());
+                            command = savedCommandName;
+                        }
+                        // If the factory is still null, use the Run command as the default
+                        else if (factories.TryGetValue(Commands.Run, out factory))
+                        {
+                            args = ImmutableArray.Create(savedCommandArgs.ToArray());
+                            command = Commands.Run;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Since `run` is the default command, the alias could be saved without
an explicit command. When reading the alias in that case, we couldn't
find a matching factory and ignored the entire alias arguments.

This commit adds a fallback so that if the first alias argument cannot
be interpreted as a command, we also apply the default behavior for the
non-save scenario and try it as a `Run` command instead.