### PR TITLE
Reintroduce --version option in a vswhere-compatible way

### DIFF
--- a/src/VisualStudio.Tests/ProgramTests.cs
+++ b/src/VisualStudio.Tests/ProgramTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
@@ -17,12 +17,11 @@ namespace Devlooped.Tests
 
 
         [Theory]
-        [InlineData(null)]
         [InlineData("/help")]
         [InlineData("/?")]
         [InlineData("-?")]
         [InlineData("/h")]
-        public async Task when_running_without_args_or_with_help_arg_then_usage_is_shown(params string[] args)
+        public async Task when_running_with_help_arg_then_usage_is_shown(params string[] args)
         {
             var program = new ProgramTest(output, new CommandFactory(), args ?? new string[0]);
 
@@ -32,7 +31,7 @@ namespace Devlooped.Tests
             Assert.True(program.UsageShown);
         }
 
-        [Fact(Skip = "--version disabled pending a redesign")]
+        [Fact]
         public async Task when_running_with_version_arg_then_version_is_shown()
         {
             var program = new ProgramTest(output, new CommandFactory(), "--version");
@@ -41,6 +40,21 @@ namespace Devlooped.Tests
 
             Assert.Equal(0, exitCode);
             Assert.True(program.VersionShown);
+        }
+
+        [Fact]
+        public async Task when_running_where_command_with_version_arg_then_version_is_not_shown()
+        {
+            var command = Mock.Of<Command>();
+            var commandFactory = new CommandFactory();
+            commandFactory.RegisterCommand("test", () => Mock.Of<CommandDescriptor>(), x => command);
+            var program = new ProgramTest(output, commandFactory, "test", "--version");
+
+            var exitCode = await program.RunAsync();
+
+            Assert.Equal(0, exitCode);
+            Assert.False(program.VersionShown);
+            Mock.Get(command).Verify(x => x.ExecuteAsync(output));
         }
 
         [Fact]

--- a/src/VisualStudio/Program.cs
+++ b/src/VisualStudio/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
@@ -40,19 +40,20 @@ namespace Devlooped
 
         public async Task<int> RunAsync()
         {
-            if (args.Length == 0 || new[] { "?", "-?", "/?", "-h", "/h", "--help", "/help" }.Contains(args[0]))
+            if (args.Length != 0 && new[] { "?", "-?", "/?", "-h", "/h", "--help", "/help" }.Contains(args[0]))
             {
                 ShowUsage();
                 return 0;
             }
-            //else if (VersionOption.IsDefined(args))
-            //{
-            //    ShowVersion();
-            //    return 0;
-            //}
+            if (args.Length != 0 && VersionOption.IsDefined(new[] { args[0] }))
+            {
+                // Only consider --version if it's the *first* argument defined.
+                ShowVersion();
+                return 0;
+            }
 
-            var commandName = args[0];
-            var commandArgs = ImmutableArray.Create(args.Skip(1).ToArray());
+            var commandName = args.Length == 0 ? Commands.Run : args[0];
+            var commandArgs = ImmutableArray.Create(args.Length == 0 ? args : args.Skip(1).ToArray());
             try
             {
                 executingCommand = await commandFactory.CreateCommandAsync(commandName, commandArgs);


### PR DESCRIPTION
We had disabled this in  9093d5a6d2d5e80d70135e61c8b98e898614fd9a because it previously interfered with the ability to run vs where with a version specifier.

We now instead check that the version is defined as the *first* argument specified, which covers that and makes it so that only `vs --version` will show it.

Fixes #72