### PR TITLE
🔄 dotnet-file sync

### DIFF
--- a/.github/workflows/dotnet-file.yml
+++ b/.github/workflows/dotnet-file.yml
@@ -11,7 +11,7 @@ env:
   GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
 jobs:
-  changelog:
+  sync:
     runs-on: windows-latest
     steps:
       - name: 🔍 GH_TOKEN
@@ -34,7 +34,7 @@ jobs:
           dotnet gcm store --protocol=https --host=github.com --username=$env:GITHUB_ACTOR --password=$env:GH_TOKEN
           gh auth status
 
-          dotnet tool update -g dotnet-file --no-cache --add-source https://pkg.kzu.io/index.json --version 42.42.42-main.75
+          dotnet tool update -g dotnet-file
           dotnet file sync -c:$env:TEMP\dotnet-file.md
           if (test-path $env:TEMP\dotnet-file.md) {
             echo 'CHANGES<<EOF' >> $env:GITHUB_ENV

--- a/.netconfig
+++ b/.netconfig
@@ -82,9 +82,9 @@
 	sha = 16ac2f336b14d6b340b10fa162242a9742eb08fc
 [file "src/Directory.Build.targets"]
 	url = https://github.com/devlooped/oss/blob/main/src/Directory.Build.targets
-	etag = f90be354c63f82bcfac68246648aee9a5a2842f1e4b66421b850939635610532
+	etag = af2cf67157f42ab43a0082cbf876aa4cc46e167e6e6df6c05e9aaf36ffb23cc8
 	weak
-	sha = d8ce9990d269b7af8a96193691c7a754d74c3dca
+	sha = 6edd918283051b5179f6255556d254654acc5b8c
 [file "src/kzu.snk"]
 	url = https://github.com/devlooped/oss/blob/main/src/kzu.snk
 	etag = b8d789b5b6bea017cdcc8badcea888ad78de3e34298efca922054e9fb0e7b6b9
@@ -153,6 +153,6 @@
 	sha = f2dc1370469bec1b2d32d82faf659b050cdc7e2a
 [file ".github/workflows/dotnet-file.yml"]
 	url = https://github.com/devlooped/oss/blob/main/.github/workflows/dotnet-file.yml
-	sha = e977ded975b1a536e76d5577a15a8512570ad8c7
-	etag = a84e35210d22591f420ba49ffed469e23107fbccb685857a20188134026d91bd
+	sha = 3e864109790fc5c4a42edc106d9dd3ad4b204973
+	etag = 209e73911e3ae74c2ead29a17854398f0802023bbb8d83e91bbb303e254ac1e3
 	weak

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -33,11 +33,6 @@
     <OutDir>$(OutputPath)</OutDir>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- Define constant for TF like NET5, NET472, NETSTANDARD2, NETSTANDARD21 -->
-    <DefineConstants Condition="'$(TargetFramework)' != '' and '$(TargetFrameworks)' != ''">$(DefineConstants);$(TargetFramework.ToUpperInvariant().TrimEnd('0').TrimEnd('.').Replace('.', ''))</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <!-- Consider the project out of date if any of these files changes -->
     <UpToDateCheck Include="@(PackageFile);@(None);@(Content);@(EmbeddedResource)" />


### PR DESCRIPTION
# devlooped/oss

- Rename changelog to sync [devlooped/oss@99c4bb7](https://github.com/devlooped/oss/commit/99c4bb740c516bd2953464f4fdbfa32bcbde6352)
- Update to public stable version of dotnet-file [devlooped/oss@3e86410](https://github.com/devlooped/oss/commit/3e864109790fc5c4a42edc106d9dd3ad4b204973)
- Define target framework constant always, not only for multi-targeting [devlooped/oss@872f3ab](https://github.com/devlooped/oss/commit/872f3ab674ed375636eab6a34ae5d38426012ace)
- Remove DefineConstant since .NET5 SDK already provides them [devlooped/oss@6edd918](https://github.com/devlooped/oss/commit/6edd918283051b5179f6255556d254654acc5b8c)