### PR TITLE
Fix renamed/removed .NETCore workload for 2022

### DIFF
--- a/src/VisualStudio/Commands/InstallCommand.cs
+++ b/src/VisualStudio/Commands/InstallCommand.cs
@@ -30,8 +30,13 @@ namespace Devlooped
 
             args.AddRange(Descriptor.ExtraArguments);
 
+            // See also InstallerService.RunAsync where we do this mapping too.
+            var vs = Descriptor.Channel == null || Descriptor.Channel == Channel.Release ? "16" : "17";
+
             // TODO: for now, we assume we're always doing an install.
-            var installBase = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Microsoft Visual Studio", "2019");
+            var installBase = vs == "16" ?
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Microsoft Visual Studio", "2019") :
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Microsoft Visual Studio", "2022");
 
             // There is at least one install already, so use nicknames for the new one.
             if (Directory.Exists(installBase) && !args.Contains("--nickname"))

--- a/src/VisualStudio/InstallerService.cs
+++ b/src/VisualStudio/InstallerService.cs
@@ -28,6 +28,11 @@ namespace Devlooped
         Task RunAsync(string command, Channel? channel, Sku? sku, IEnumerable<string> args, TextWriter output)
         {
             var vs = channel == null || channel == Channel.Release ? "16" : "17";
+
+            // Microsoft.VisualStudio.Workload.NetCoreTools > Microsoft.NetCore.Component.DevelopmentTools
+            if (vs == "17")
+                args = args.Select(arg => arg == "Microsoft.VisualStudio.Workload.NetCoreTools" ? "Microsoft.NetCore.Component.DevelopmentTools" : arg);
+
             return RunAsync(command, $"https://aka.ms/vs/{vs}/{MapChannel(channel)}", sku, args, output);
         }
 


### PR DESCRIPTION
The +core alias should now map to the minimal component for doing .NET6 development under 2022.

Fixes #106