### PR TITLE
Add support for Visual Studio 18 channel identifiers

### DIFF
--- a/src/VisualStudio/VisualStudioInstanceExtensions.cs
+++ b/src/VisualStudio/VisualStudioInstanceExtensions.cs
@@ -28,6 +28,10 @@ namespace vswhere
                 "VisualStudio.17.Preview" => Channel.Preview,
                 "VisualStudio.17.IntPreview" => Channel.IntPreview,
                 "VisualStudio.17.int.main" => Channel.Main,
+                "VisualStudio.18.Release" => Channel.Release,
+                "VisualStudio.18.Preview" => Channel.Preview,
+                "VisualStudio.18.IntPreview" => Channel.IntPreview,
+                "VisualStudio.18.int.main" => Channel.Main,
                 _ => null,
             };
     }


### PR DESCRIPTION
Map new VisualStudio.18.* channel strings to their corresponding Channel enum values to ensure proper recognition and handling of future Visual Studio 18 (2025) installations.