### PR TITLE
chore(deps): bump packages and upgrade to .NET 8.0

### DIFF
--- a/src/Directory.targets
+++ b/src/Directory.targets
@@ -2,7 +2,8 @@
   <!-- Extend the Directory.Build.targets -->
 
   <ItemGroup Condition="Exists('$(MSBuildThisFileDirectory)..\..\ThisAssembly\bin\')">
-    <PackageReference Update="ThisAssembly" Version="1.0.9" />
+    <PackageReference Update="ThisAssembly.Project" Version="2.1.2" />
+    <PackageReference Update="ThisAssembly.AssemblyInfo" Version="2.1.2" />
   </ItemGroup>
 
 </Project>

--- a/src/VisualStudio.Tests/VisualStudio.Tests.csproj
+++ b/src/VisualStudio.Tests/VisualStudio.Tests.csproj
@@ -1,16 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Devlooped.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetConfig" Version="1.0.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="DotNetConfig" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VisualStudio/VisualStudio.csproj
+++ b/src/VisualStudio/VisualStudio.csproj
@@ -24,7 +24,7 @@ See full documentation at $(PackageProjectUrl).
 </Description>
 
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
 
     <AssemblyName>vs</AssemblyName>
@@ -42,15 +42,16 @@ See full documentation at $(PackageProjectUrl).
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.Web" Version="1.2.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.202" PrivateAssets="all" />
+    <PackageReference Include="Devlooped.Web" Version="1.4.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />
     <PackageReference Include="vswhere" Version="3.1.7" PrivateAssets="all" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
-    <PackageReference Include="ThisAssembly" Version="1.0.9" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly.AssemblyInfo" Version="2.1.2" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly.Project" Version="2.1.2" PrivateAssets="all" />
     <PackageReference Include="System.Management" Version="10.0.9" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.6.0" />
-    <PackageReference Include="DotNetConfig" Version="1.0.6" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.3.0" />
+    <PackageReference Include="DotNetConfig" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bump all direct dependencies (some of which are part of chains that have received security fixes) and upgrade the target framework from the EOL `net6.0` (no security updates) to `net8.0`.

### Changes
* TargetFramework: `net6.0` → `net8.0` (both projects)
* Devlooped.Web: 1.2.0 → 1.4.0
* DotNetConfig: 1.0.6 → 1.2.0
* Microsoft.CodeAnalysis.CSharp.Scripting: 4.6.0 → 5.3.0
* Microsoft.SourceLink.GitHub: 10.0.202 → 10.0.300
* Microsoft.NET.Test.Sdk: 17.13.0 → 18.7.0
* Moq: 4.18.4 → 4.20.72
* xunit.runner.visualstudio: 3.0.2 → 3.1.5
* ThisAssembly: updated to v2 split packages (`ThisAssembly.Project` + `ThisAssembly.AssemblyInfo`) to avoid generator issues with embedded `Docs\*.md`

`dotnet build` and `dotnet test` (171 tests) pass cleanly.

No vulnerable packages reported by `dotnet list package --vulnerable`.
