### PR TITLE
Target Visual Studio 2026 stable/18 install paths

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,4 @@
-![Icon](https://raw.githubusercontent.com/devlooped/dotnet-vs/main/docs/img/icon-32.png) dotnet-vs
-============
+<h1 id="dotnet-vs"><img src="https://raw.githubusercontent.com/devlooped/dotnet-vs/main/docs/img/icon.svg" alt="icon" height="32" width="32" style="vertical-align: text-top; border: 0px; padding: 0px; margin: 0px">  dotnet-vs</h1>
 
 A global tool for running, managing and querying Visual Studio installations
 
@@ -45,7 +44,7 @@ Examples:
 
 <!-- EXAMPLES_BEGIN -->
 ```
-# Save the first VS enterprise with the Xamarin/Mobile workload as the "mobile" alias
+# Save the first VS enterprise with the Maui/Mobile workload as the "mobile" alias
 > vs -sku:ent -first +mobile -save:mobile
 
 # Runs the saved alias with all the original arguments
@@ -63,8 +62,8 @@ Usage: vs client [options]
 
 |Option|Description|
 |-|-|
-| `rel\|release` | Run release version |
-| `pre\|preview` | Run preview version |
+| `stable` | Run stable version |
+| `insiders` | Run insiders version |
 | `int\|internal` | Run internal (aka 'dogfood') version |
 | `sku:` | Edition, one of `e\|ent\|enterprise`, `p\|pro\|professional`, `c\|com\|community`, `b\|build\|buildtools` or `t\|test\|testagent` |
 | `filter:` | Expression to filter VS instances. E.g. `x => x.InstanceId = '123'` |
@@ -83,8 +82,8 @@ Usage: vs config [options]
 
 |Option|Description|
 |-|-|
-| `rel\|release` | open release version |
-| `pre\|preview` | open preview version |
+| `stable` | open stable version |
+| `insiders` | open insiders version |
 | `int\|internal` | open internal (aka 'dogfood') version |
 | `sku:` | Edition, one of `e\|ent\|enterprise`, `p\|pro\|professional`, `c\|com\|community`, `b\|build\|buildtools` or `t\|test\|testagent` |
 | `filter:` | Expression to filter VS instances. E.g. `x => x.InstanceId = '123'` |
@@ -102,8 +101,8 @@ Usage: vs install [options]
 
 |Option|Description|
 |-|-|
-| `rel\|release` | install release version |
-| `pre\|preview` | install preview version |
+| `stable` | install stable version |
+| `insiders` | install insiders version |
 | `int\|internal` | install internal (aka 'dogfood') version |
 | `sku:` | Edition, one of `e\|ent\|enterprise`, `p\|pro\|professional`, `c\|com\|community`, `b\|build\|buildtools` or `t\|test\|testagent` |
 | `filter:` | Expression to filter VS instances. E.g. `x => x.InstanceId = '123'` |
@@ -113,7 +112,7 @@ Usage: vs install [options]
 You can add specific workload IDs by using the supported [workload switches](#workload-id-switches) 
 using the `+` prefix.
 
-See the [documentation for the Visual Studio installer command line options](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio?view=vs-2019#install-options) 
+See the [documentation for the Visual Studio installer command line options](https://learn.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio) 
 for the full list of arguments that can be provided.
 
 Common options are `--passive`, `quiet` and `--wait`, for example.
@@ -142,8 +141,8 @@ Usage: vs kill [options]
 
 |Option|Description|
 |-|-|
-| `rel\|release` | kill release version |
-| `pre\|preview` | kill preview version |
+| `stable` | kill stable version |
+| `insiders` | kill insiders version |
 | `int\|internal` | kill internal (aka 'dogfood') version |
 | `sku:` | Edition, one of `e\|ent\|enterprise`, `p\|pro\|professional`, `c\|com\|community`, `b\|build\|buildtools` or `t\|test\|testagent` |
 | `filter:` | Expression to filter VS instances. E.g. `x => x.InstanceId = '123'` |
@@ -171,8 +170,8 @@ Usage: vs log [options]
 
 |Option|Description|
 |-|-|
-| `rel\|release` | open release version |
-| `pre\|preview` | open preview version |
+| `stable` | open stable version |
+| `insiders` | open insiders version |
 | `int\|internal` | open internal (aka 'dogfood') version |
 | `sku:` | Edition, one of `e\|ent\|enterprise`, `p\|pro\|professional`, `c\|com\|community`, `b\|build\|buildtools` or `t\|test\|testagent` |
 | `filter:` | Expression to filter VS instances. E.g. `x => x.InstanceId = '123'` |
@@ -190,8 +189,8 @@ Usage: vs modify [options]
 
 |Option|Description|
 |-|-|
-| `rel\|release` | modify release version |
-| `pre\|preview` | modify preview version |
+| `stable` | modify stable version |
+| `insiders` | modify insiders version |
 | `int\|internal` | modify internal (aka 'dogfood') version |
 | `sku:` | Edition, one of `e\|ent\|enterprise`, `p\|pro\|professional`, `c\|com\|community`, `b\|build\|buildtools` or `t\|test\|testagent` |
 | `filter:` | Expression to filter VS instances. E.g. `x => x.InstanceId = '123'` |
@@ -208,7 +207,7 @@ Examples:
 <!-- EXAMPLES_BEGIN -->
 ```
 # Add .NET Core Workload to installed Visual Studio Preview
-> vs modify preview +core
+> vs modify insiders +core
 ```
 <!-- EXAMPLES_END -->
 
@@ -222,15 +221,15 @@ Usage: vs run [options]
 
 |Option|Description|
 |-|-|
-| `rel\|release` | run release version |
-| `pre\|preview` | run preview version |
+| `stable` | run stable version |
+| `insiders` | run insiders version |
 | `int\|internal` | run internal (aka 'dogfood') version |
 | `sku:` | Edition, one of `e\|ent\|enterprise`, `p\|pro\|professional`, `c\|com\|community`, `b\|build\|buildtools` or `t\|test\|testagent` |
 | `filter:` | Expression to filter VS instances. E.g. `x => x.InstanceId = '123'` |
 | `exp\|experimental` | run experimental instance instead of regular. |
 | `id:` | Run a specific instance by its ID |
 | `f\|first` | If more than one instance matches the criteria, run the first one sorted by descending build version. |
-| `v\|version:` | Run specific (semantic) version, such as 16.4 or 16.5.3. |
+| `v\|version:` | Run specific (semantic) version, such as 18.7 or 18.7.3 |
 | `w\|wait` | Wait for the started Visual Studio to exit. |
 | `nr\|nodereuse` | Disable MSBuild node reuse. Useful when testing analyzers, tasks and targets. Defaults to true when running experimental instance. |
 | `default` | Set as the default version to run when no arguments are provided, or remove the current default (with --default-). |
@@ -248,14 +247,14 @@ Examples:
 
 <!-- EXAMPLES_BEGIN -->
 ```
-# Runs the first VS enterprise with the Maui workload
-> vs -sku:ent -first +maui
+# Runs the first VS enterprise with the Maui/Mobile workload
+> vs -sku:ent -first +mobile
 
-# Runs VS 16.8
-> vs -v:16.8
+# Runs VS 18.7
+> vs -v:18.7
 
-# Runs VS 16.9 preview
-> vs -v:16.9 -pre
+# Runs VS 18 Insiders
+> vs -v:18 -insiders
 
 # Runs the last VS that was run
 > vs
@@ -272,8 +271,8 @@ Usage: vs update [options]
 
 |Option|Description|
 |-|-|
-| `rel\|release` | Update release version |
-| `pre\|preview` | Update preview version |
+| `stable` | Update stable version |
+| `insiders` | Update insiders version |
 | `int\|internal` | Update internal (aka 'dogfood') version |
 | `sku:` | Edition, one of `e\|ent\|enterprise`, `p\|pro\|professional`, `c\|com\|community`, `b\|build\|buildtools` or `t\|test\|testagent` |
 | `filter:` | Expression to filter VS instances. E.g. `x => x.InstanceId = '123'` |
@@ -291,8 +290,8 @@ Usage: vs where [options]
 
 |Option|Description|
 |-|-|
-| `rel\|release` | show release version |
-| `pre\|preview` | show preview version |
+| `stable` | show stable version |
+| `insiders` | show insiders version |
 | `int\|internal` | show internal (aka 'dogfood') version |
 | `sku:` | Edition, one of `e\|ent\|enterprise`, `p\|pro\|professional`, `c\|com\|community`, `b\|build\|buildtools` or `t\|test\|testagent` |
 | `filter:` | Expression to filter VS instances. E.g. `x => x.InstanceId = '123'` |
@@ -384,42 +383,11 @@ intuitive command line, such as `vs install +mobile -sku:enterprise` or `vs +mob
 prefix to add or remove workloads respectively, for example.
 
 
-<!-- include https://github.com/devlooped/sponsors/raw/main/footer.md -->
-# Sponsors 
+## Sponsors
 
-<!-- sponsors.md -->
-[![Clarius Org](https://avatars.githubusercontent.com/u/71888636?v=4&s=39 "Clarius Org")](https://github.com/clarius)
-[![MFB Technologies, Inc.](https://avatars.githubusercontent.com/u/87181630?v=4&s=39 "MFB Technologies, Inc.")](https://github.com/MFB-Technologies-Inc)
-[![SandRock](https://avatars.githubusercontent.com/u/321868?u=99e50a714276c43ae820632f1da88cb71632ec97&v=4&s=39 "SandRock")](https://github.com/sandrock)
-[![DRIVE.NET, Inc.](https://avatars.githubusercontent.com/u/15047123?v=4&s=39 "DRIVE.NET, Inc.")](https://github.com/drivenet)
-[![Keith Pickford](https://avatars.githubusercontent.com/u/16598898?u=64416b80caf7092a885f60bb31612270bffc9598&v=4&s=39 "Keith Pickford")](https://github.com/Keflon)
-[![Thomas Bolon](https://avatars.githubusercontent.com/u/127185?u=7f50babfc888675e37feb80851a4e9708f573386&v=4&s=39 "Thomas Bolon")](https://github.com/tbolon)
-[![Kori Francis](https://avatars.githubusercontent.com/u/67574?u=3991fb983e1c399edf39aebc00a9f9cd425703bd&v=4&s=39 "Kori Francis")](https://github.com/kfrancis)
-[![Reuben Swartz](https://avatars.githubusercontent.com/u/724704?u=2076fe336f9f6ad678009f1595cbea434b0c5a41&v=4&s=39 "Reuben Swartz")](https://github.com/rbnswartz)
-[![Jacob Foshee](https://avatars.githubusercontent.com/u/480334?v=4&s=39 "Jacob Foshee")](https://github.com/jfoshee)
-[![](https://avatars.githubusercontent.com/u/33566379?u=bf62e2b46435a267fa246a64537870fd2449410f&v=4&s=39 "")](https://github.com/Mrxx99)
-[![Eric Johnson](https://avatars.githubusercontent.com/u/26369281?u=41b560c2bc493149b32d384b960e0948c78767ab&v=4&s=39 "Eric Johnson")](https://github.com/eajhnsn1)
-[![Jonathan ](https://avatars.githubusercontent.com/u/5510103?u=98dcfbef3f32de629d30f1f418a095bf09e14891&v=4&s=39 "Jonathan ")](https://github.com/Jonathan-Hickey)
-[![Ken Bonny](https://avatars.githubusercontent.com/u/6417376?u=569af445b6f387917029ffb5129e9cf9f6f68421&v=4&s=39 "Ken Bonny")](https://github.com/KenBonny)
-[![Simon Cropp](https://avatars.githubusercontent.com/u/122666?v=4&s=39 "Simon Cropp")](https://github.com/SimonCropp)
-[![agileworks-eu](https://avatars.githubusercontent.com/u/5989304?v=4&s=39 "agileworks-eu")](https://github.com/agileworks-eu)
-[![Zheyu Shen](https://avatars.githubusercontent.com/u/4067473?v=4&s=39 "Zheyu Shen")](https://github.com/arsdragonfly)
-[![Vezel](https://avatars.githubusercontent.com/u/87844133?v=4&s=39 "Vezel")](https://github.com/vezel-dev)
-[![ChilliCream](https://avatars.githubusercontent.com/u/16239022?v=4&s=39 "ChilliCream")](https://github.com/ChilliCream)
-[![4OTC](https://avatars.githubusercontent.com/u/68428092?v=4&s=39 "4OTC")](https://github.com/4OTC)
-[![domischell](https://avatars.githubusercontent.com/u/66068846?u=0a5c5e2e7d90f15ea657bc660f175605935c5bea&v=4&s=39 "domischell")](https://github.com/DominicSchell)
-[![Adrian Alonso](https://avatars.githubusercontent.com/u/2027083?u=129cf516d99f5cb2fd0f4a0787a069f3446b7522&v=4&s=39 "Adrian Alonso")](https://github.com/adalon)
-[![torutek](https://avatars.githubusercontent.com/u/33917059?v=4&s=39 "torutek")](https://github.com/torutek)
-[![Ryan McCaffery](https://avatars.githubusercontent.com/u/16667079?u=c0daa64bb5c1b572130e05ae2b6f609ecc912d4d&v=4&s=39 "Ryan McCaffery")](https://github.com/mccaffers)
-[![Seika Logiciel](https://avatars.githubusercontent.com/u/2564602?v=4&s=39 "Seika Logiciel")](https://github.com/SeikaLogiciel)
-[![Andrew Grant](https://avatars.githubusercontent.com/devlooped-user?s=39 "Andrew Grant")](https://github.com/wizardness)
-[![eska-gmbh](https://avatars.githubusercontent.com/devlooped-team?s=39 "eska-gmbh")](https://github.com/eska-gmbh)
-[![Geodata AS](https://avatars.githubusercontent.com/u/5946299?v=4&s=39 "Geodata AS")](https://github.com/geodata-no)
+<h3 style="vertical-align: text-top" id="by-clarius">
+<img src="https://raw.githubusercontent.com/devlooped/oss/main/assets/images/sponsors.svg" alt="sponsors" height="36" width="36" style="vertical-align: text-top; border: 0px; padding: 0px; margin: 0px">&nbsp;&nbsp;by&nbsp;<a href="https://github.com/clarius">@clarius</a>&nbsp;<img src="https://raw.githubusercontent.com/clarius/branding/main/logo/logo.svg" alt="sponsors" height="36" width="36" style="vertical-align: text-top; border: 0px; padding: 0px; margin: 0px">
+</h3>
 
+*[get mentioned here too](https://github.com/sponsors/devlooped)!*
 
-<!-- sponsors.md -->
-[![Sponsor this project](https://avatars.githubusercontent.com/devlooped-sponsor?s=118 "Sponsor this project")](https://github.com/sponsors/devlooped)
-
-[Learn more about GitHub Sponsors](https://github.com/sponsors)
-
-<!-- https://github.com/devlooped/sponsors/raw/main/footer.md -->

--- a/src/VisualStudio.Tests/VisualStudioInstanceExtensions.cs
+++ b/src/VisualStudio.Tests/VisualStudioInstanceExtensions.cs
@@ -15,12 +15,13 @@ namespace vswhere
             { Sku.TestAgent, "Microsoft.VisualStudio.Product.TestAgent" }
         };
 
+        // Channel IDs still use Release/Preview names even though CLI uses Stable/Insiders.
         static readonly Dictionary<Channel, string> productIdByChannel = new Dictionary<Channel, string>
         {
-            { Channel.Release, "VisualStudio.16.Release" },
-            { Channel.Preview, "VisualStudio.16.Preview" },
-            { Channel.IntPreview, "VisualStudio.16.IntPreview" },
-            { Channel.Main, "VisualStudio.16.int.main" },
+            { Channel.Stable, "VisualStudio.18.Release" },
+            { Channel.Insiders, "VisualStudio.18.Preview" },
+            { Channel.IntPreview, "VisualStudio.18.IntPreview" },
+            { Channel.Main, "VisualStudio.18.int.main" },
         };
 
         public static VisualStudioInstance WithSku(this VisualStudioInstance vsInstance, Sku sku)

--- a/src/VisualStudio.Tests/VisualStudioOptionsTests.cs
+++ b/src/VisualStudio.Tests/VisualStudioOptionsTests.cs
@@ -9,16 +9,22 @@ namespace Devlooped.Tests
     {
         [Theory]
         [InlineData("", default)]
-        [InlineData("rel", Channel.Release)]
-        [InlineData("release", Channel.Release)]
-        [InlineData("Release", Channel.Release)]
-        [InlineData("--rel", Channel.Release)]
-        [InlineData("--release", Channel.Release)]
-        [InlineData("pre", Channel.Preview)]
-        [InlineData("preview", Channel.Preview)]
-        [InlineData("Preview", Channel.Preview)]
-        [InlineData("--pre", Channel.Preview)]
-        [InlineData("--preview", Channel.Preview)]
+        [InlineData("stable", Channel.Stable)]
+        [InlineData("Stable", Channel.Stable)]
+        [InlineData("--stable", Channel.Stable)]
+        [InlineData("rel", Channel.Stable)]
+        [InlineData("release", Channel.Stable)]
+        [InlineData("Release", Channel.Stable)]
+        [InlineData("--rel", Channel.Stable)]
+        [InlineData("--release", Channel.Stable)]
+        [InlineData("insiders", Channel.Insiders)]
+        [InlineData("Insiders", Channel.Insiders)]
+        [InlineData("--insiders", Channel.Insiders)]
+        [InlineData("pre", Channel.Insiders)]
+        [InlineData("preview", Channel.Insiders)]
+        [InlineData("Preview", Channel.Insiders)]
+        [InlineData("--pre", Channel.Insiders)]
+        [InlineData("--preview", Channel.Insiders)]
         [InlineData("int", Channel.IntPreview)]
         [InlineData("internal", Channel.IntPreview)]
         [InlineData("--int", Channel.IntPreview)]
@@ -164,14 +170,14 @@ namespace Devlooped.Tests
         static (string[] Arguments, Func<VisualStudioOptions, bool> VerifyResult)[] TestCases =>
             new (string[] Arguments, Func<VisualStudioOptions, bool> VerifyResult)[]
             {
-                (new [] { "enterprise" , "preview" }, x => x.Sku == Sku.Enterprise && x.Channel == Channel.Preview),
+                (new [] { "enterprise" , "insiders" }, x => x.Sku == Sku.Enterprise && x.Channel == Channel.Insiders),
                 (new [] { "main" , "exp" }, x => x.Channel == Channel.Main && x.IsExperimental),
                 (new [] { "all", "exp" }, x => x.All && x.IsExperimental),
                 (new [] { "ent", "main" }, x => x.Sku == Sku.Enterprise && x.Channel == Channel.Main),
                 (new [] { "main", "x => x.InstanceId == '123'" }, x => x.Channel == Channel.Main && x.Expression == "x => x.InstanceId == \"123\""),
-                (new [] { "pro" , "release", "--nick=foo" }, x => x.Sku == Sku.Professional && x.Channel == Channel.Release && x.Nickname == "foo"),
-                (new [] { "build", "release" }, x => x.Sku == Sku.BuildTools && x.Channel == Channel.Release),
-                (new [] { "test", "release" }, x => x.Sku == Sku.TestAgent && x.Channel == Channel.Release)
+                (new [] { "pro" , "stable", "--nick=foo" }, x => x.Sku == Sku.Professional && x.Channel == Channel.Stable && x.Nickname == "foo"),
+                (new [] { "build", "release" }, x => x.Sku == Sku.BuildTools && x.Channel == Channel.Stable),
+                (new [] { "test", "stable" }, x => x.Sku == Sku.TestAgent && x.Channel == Channel.Stable)
             };
 
         // Hack to use typed func and avoid to make VisualStudioOptions type public

--- a/src/VisualStudio.Tests/VisualStudioPredicateBuilderTests.cs
+++ b/src/VisualStudio.Tests/VisualStudioPredicateBuilderTests.cs
@@ -26,11 +26,11 @@ namespace Devlooped.Tests
         {
             var builder = new VisualStudioPredicateBuilder();
 
-            var predicate = await builder.BuildPredicateAsync(GetOptions(channel: Channel.Preview));
+            var predicate = await builder.BuildPredicateAsync(GetOptions(channel: Channel.Insiders));
 
-            Assert.True(predicate(new vswhere.VisualStudioInstance().WithChannel(Channel.Preview)));
+            Assert.True(predicate(new vswhere.VisualStudioInstance().WithChannel(Channel.Insiders)));
             Assert.False(predicate(new vswhere.VisualStudioInstance().WithChannel(Channel.IntPreview)));
-            Assert.False(predicate(new vswhere.VisualStudioInstance().WithChannel(Channel.Release)));
+            Assert.False(predicate(new vswhere.VisualStudioInstance().WithChannel(Channel.Stable)));
             Assert.False(predicate(new vswhere.VisualStudioInstance().WithChannel(Channel.Main)));
         }
 
@@ -61,7 +61,7 @@ namespace Devlooped.Tests
             Assert.True(predicate(new vswhere.VisualStudioInstance() { InstanceId = "123" }.WithSku(Sku.Professional).WithChannel(Channel.IntPreview)));
             Assert.False(predicate(new vswhere.VisualStudioInstance() { InstanceId = "456" }.WithSku(Sku.Professional).WithChannel(Channel.IntPreview)));
             Assert.False(predicate(new vswhere.VisualStudioInstance() { InstanceId = "123" }.WithSku(Sku.Enterprise).WithChannel(Channel.IntPreview)));
-            Assert.False(predicate(new vswhere.VisualStudioInstance() { InstanceId = "123" }.WithSku(Sku.Professional).WithChannel(Channel.Release)));
+            Assert.False(predicate(new vswhere.VisualStudioInstance() { InstanceId = "123" }.WithSku(Sku.Professional).WithChannel(Channel.Stable)));
         }
 
         IOptions GetOptions(Sku? sku = null, Channel? channel = null, string expression = null) =>

--- a/src/VisualStudio/Channel.cs
+++ b/src/VisualStudio/Channel.cs
@@ -2,8 +2,8 @@
 {
     public enum Channel
     {
-        Release,
-        Preview,
+        Stable,
+        Insiders,
         IntPreview,
         Main,
     }

--- a/src/VisualStudio/Commands/InstallCommand.cs
+++ b/src/VisualStudio/Commands/InstallCommand.cs
@@ -30,36 +30,29 @@ namespace Devlooped
 
             args.AddRange(Descriptor.ExtraArguments);
 
-            // See also InstallerService.RunAsync where we do this mapping too.
-            var vs = Descriptor.Channel == null || Descriptor.Channel == Channel.Release ? "16" : "17";
-
-            // TODO: for now, we assume we're always doing an install.
-            var installBase = vs == "16" ?
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Microsoft Visual Studio", "2019") :
-                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Microsoft Visual Studio", "2022");
+            var vs = await installerService.GetLatestMajorAsync();
+            var installBase = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+                "Microsoft Visual Studio",
+                vs);
 
             // There is at least one install already, so use nicknames for the new one.
             if (Directory.Exists(installBase) && !args.Contains("--nickname"))
             {
                 args.Add("--nickname");
-                if (Descriptor.Channel == Channel.Preview)
-                    args.Add("Preview");
-                else if (Descriptor.Channel == Channel.IntPreview)
-                    args.Add("IntPreview");
-                else if (Descriptor.Channel == Channel.Main)
-                    args.Add("main");
-                else
-                    args.Add(Descriptor.Sku.ToString().Substring(0, 3));
+                args.Add(ChannelFolderName(Descriptor.Channel) ?? Descriptor.Sku.ToString().Substring(0, 3));
             }
 
             var installPath = Path.Combine(installBase, Descriptor.Sku.ToString());
             var customPath = Directory.Exists(installPath);
             if (customPath)
             {
-                installPath = Path.Combine(installBase, Descriptor.Channel == Channel.Preview ? "Preview" : Descriptor.Channel == Channel.IntPreview ? "IntPreview" : Descriptor.Sku.ToString());
+                installPath = Path.Combine(installBase, ChannelFolderName(Descriptor.Channel) ?? Descriptor.Sku.ToString());
                 if (Directory.Exists(installPath))
                 {
-                    installPath = Path.Combine(installBase, Descriptor.Channel == Channel.Preview ? "Pre" + Descriptor.Sku.ToString() : Descriptor.Channel == Channel.IntPreview ? "Int" + Descriptor.Sku.ToString() : Descriptor.Sku.ToString());
+                    var prefix = Descriptor.Channel == Channel.Insiders ? "Pre" :
+                        Descriptor.Channel == Channel.IntPreview ? "Int" : string.Empty;
+                    installPath = Path.Combine(installBase, prefix + Descriptor.Sku.ToString());
                 }
             }
 
@@ -69,7 +62,16 @@ namespace Devlooped
                 args.Add(installPath);
             }
 
-            await installerService.InstallAsync(Descriptor.Channel, Descriptor.Sku, args, output);
+            await installerService.InstallAsync(vs, Descriptor.Channel, Descriptor.Sku, args, output);
         }
+
+        static string ChannelFolderName(Channel? channel)
+            => channel switch
+            {
+                Channel.Insiders => "Insiders",
+                Channel.IntPreview => "IntPreview",
+                Channel.Main => "main",
+                _ => null,
+            };
     }
 }

--- a/src/VisualStudio/Commands/RunCommandDescriptor.cs
+++ b/src/VisualStudio/Commands/RunCommandDescriptor.cs
@@ -18,7 +18,7 @@ namespace Devlooped
                     {
                         { "id:", "Run a specific instance by its ID", i => Id = i },
                         { "f|first", "If more than one instance matches the criteria, run the first one sorted by descending build version.", f => First = f != null },
-                        { "v|version:", "Run specific (semantic) version, such as 16.8 or 16.9.2", v => Version = v },
+                        { "v|version:", "Run specific (semantic) version, such as 18.7 or 18.7.3", v => Version = v },
                         { "w|wait", "Wait for the started Visual Studio to exit.", w => Wait = w != null },
                         { "nr|nodereuse", "Disable MSBuild node reuse. Useful when testing analyzers, tasks and targets. Defaults to true when running experimental instance.", nr => DisableNodeReuse = nr != null },
                         { "default", "Set as the default version to run when no arguments are provided, or remove the current default (with --default-).", d => SetDefault = d != null },

--- a/src/VisualStudio/Docs/install.md
+++ b/src/VisualStudio/Docs/install.md
@@ -11,7 +11,7 @@
 You can add specific workload IDs by using the supported [workload switches](#workload-id-switches) 
 using the `+` prefix.
 
-See the [documentation for the Visual Studio installer command line options](https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio?view=vs-2019#install-options) 
+See the [documentation for the Visual Studio installer command line options](https://learn.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio) 
 for the full list of arguments that can be provided.
 
 Common options are `--passive`, `quiet` and `--wait`, for example.

--- a/src/VisualStudio/Docs/modify.md
+++ b/src/VisualStudio/Docs/modify.md
@@ -16,6 +16,6 @@ Examples:
 <!-- EXAMPLES_BEGIN -->
 ```
 # Add .NET Core Workload to installed Visual Studio Preview
-> vs modify preview +core
+> vs modify insiders +core
 ```
 <!-- EXAMPLES_END -->

--- a/src/VisualStudio/Docs/run.md
+++ b/src/VisualStudio/Docs/run.md
@@ -22,11 +22,11 @@ Examples:
 # Runs the first VS enterprise with the Maui/Mobile workload
 > vs -sku:ent -first +mobile
 
-# Runs VS 16.8
-> vs -v:16.8
+# Runs VS 18.7
+> vs -v:18.7
 
-# Runs VS 16.9 preview
-> vs -v:16.9 -pre
+# Runs VS 18 Insiders
+> vs -v:18 -insiders
 
 # Runs the last VS that was run
 > vs

--- a/src/VisualStudio/InstallerService.cs
+++ b/src/VisualStudio/InstallerService.cs
@@ -6,24 +6,48 @@ using System.Linq;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Devlooped.Web;
 
 namespace Devlooped
 {
     class InstallerService
     {
-        public Task InstallAsync(Channel? channel, Sku? sku, IEnumerable<string> args, TextWriter output)
+        /// <summary>
+        /// Resolves the latest Visual Studio major version by following the
+        /// unversioned stable bootstrapper redirect (e.g. /vs/stable/ → /vs/18/stable/).
+        /// </summary>
+        public async Task<string> GetLatestMajorAsync()
         {
-            // determine what's the latest & greatest VS from the docs site
-            // TODO: if the channel is preview, there' no easy way to get the major version from the web.
-            var html = HtmlDocument.Load("https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio");
-            var vs = html.CssSelectElements("a[href^=https://aka.ms/vs/][href$=/vs_enterprise.exe]")
-                .Select(e => Regex.Match(e.Attribute("href").Value!, "/(\\d\\d)/").Groups[1].Value)
-                .OrderByDescending(x => x)
-                .FirstOrDefault() ?? "17";
+            try
+            {
+                using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+                using var client = new HttpClient(handler);
+                using var request = new HttpRequestMessage(HttpMethod.Head, "https://aka.ms/vs/stable/vs_enterprise.exe");
+                using var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
 
-            return RunAsync(string.Empty, vs, channel, sku, args, output);
+                var location = response.Headers.Location?.ToString();
+                if (!string.IsNullOrEmpty(location))
+                {
+                    var match = Regex.Match(location, @"/vs/(\d+)/");
+                    if (match.Success)
+                        return match.Groups[1].Value;
+                }
+            }
+            catch
+            {
+                // Fall back below.
+            }
+
+            return "18";
         }
+
+        public async Task InstallAsync(Channel? channel, Sku? sku, IEnumerable<string> args, TextWriter output)
+        {
+            var vs = await GetLatestMajorAsync();
+            await RunAsync(string.Empty, vs, channel, sku, args, output);
+        }
+
+        public Task InstallAsync(string vs, Channel? channel, Sku? sku, IEnumerable<string> args, TextWriter output)
+            => RunAsync(string.Empty, vs, channel, sku, args, output);
 
         public Task UpdateAsync(string vs, Channel? channel, Sku? sku, IEnumerable<string> args, TextWriter output)
             => RunAsync("update", vs, channel, sku, args, output);
@@ -39,7 +63,7 @@ namespace Devlooped
 
         Task RunAsync(string command, string vs, Channel? channel, Sku? sku, IEnumerable<string> args, TextWriter output)
         {
-            // Microsoft.VisualStudio.Workload.NetCoreTools > Microsoft.NetCore.Component.DevelopmentTools
+            // Microsoft.VisualStudio.Workload.NetCoreTools was replaced starting with VS 17.
             if (int.TryParse(vs, out var major) && major >= 17)
                 args = args.Select(arg => arg == "Microsoft.VisualStudio.Workload.NetCoreTools" ? "Microsoft.NetCore.Component.DevelopmentTools" : arg);
 
@@ -75,10 +99,12 @@ namespace Devlooped
         string MapChannel(Channel? channel)
             => channel switch
             {
-                Channel.Preview => "pre",
+                Channel.Insiders => "insiders",
                 Channel.IntPreview => "intpreview",
                 Channel.Main => "int.main",
-                _ => "release"
+                // Stable is the default; Channel.Stable and null both map here.
+                // "release" is accepted on the CLI as a hidden alias for Stable.
+                _ => "stable"
             };
 
         string MapSku(Sku? sku)
@@ -101,7 +127,7 @@ namespace Devlooped
             response.EnsureSuccessStatusCode();
 
             var filePath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString(), new Uri(bootstrapperUrl).Segments.Last());
-            Directory.CreateDirectory(Path.GetDirectoryName(filePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
             using var httpStream = await response.Content.ReadAsStreamAsync();
 
             using var fileStream = File.Create(filePath);

--- a/src/VisualStudio/Options/ChannelOption.cs
+++ b/src/VisualStudio/Options/ChannelOption.cs
@@ -6,13 +6,24 @@ namespace Devlooped
 {
     class ChannelOption : OptionSet<Channel?>
     {
-        readonly static string[] shortcuts = new[] { "pre", "preview", "int", "internal", "main", "rel", "release" };
+        readonly static string[] shortcuts = new[]
+        {
+            "stable",
+            "rel", "release",
+            "insiders",
+            "pre", "preview",
+            "int", "internal",
+            "main",
+        };
 
         public ChannelOption(string verb, Channel? defaultValue = default) : base(defaultValue)
         {
-            // This is the default, that's why it's hidden
-            Add("rel|release", verb + " release version", _ => Value = Channel.Release);
-            Add("pre|preview", verb + " preview version", _ => Value = Channel.Preview);
+            Add("stable", verb + " stable version", _ => Value = Channel.Stable);
+            // Hidden alias kept for minimal backwards-compat with older CLI usage.
+            Add("rel|release", verb + " stable version", _ => Value = Channel.Stable, hidden: true);
+            Add("insiders", verb + " insiders version", _ => Value = Channel.Insiders);
+            // Hidden aliases for the old preview channel name.
+            Add("pre|preview", verb + " insiders version", _ => Value = Channel.Insiders, hidden: true);
             Add("int|internal", verb + " internal (aka 'dogfood') version", _ => Value = Channel.IntPreview);
             Add("main", verb + " main version", _ => Value = Channel.Main, hidden: true);
         }

--- a/src/VisualStudio/VisualStudio.csproj
+++ b/src/VisualStudio/VisualStudio.csproj
@@ -42,7 +42,6 @@ See full documentation at $(PackageProjectUrl).
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlooped.Web" Version="1.4.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="all" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />
     <PackageReference Include="vswhere" Version="3.1.7" PrivateAssets="all" />

--- a/src/VisualStudio/VisualStudioInstanceExtensions.cs
+++ b/src/VisualStudio/VisualStudioInstanceExtensions.cs
@@ -17,19 +17,16 @@ namespace vswhere
                 _ => throw new ArgumentException($"Invalid SKU {vsInstance.ProductId}. Must be one of {string.Join(", ", Enum.GetNames(typeof(Sku)).Select(x => x.ToLowerInvariant()))}.", "sku"),
             };
 
+        /// <summary>
+        /// Maps installed channel IDs to CLI channels.
+        /// Note: VS still uses VisualStudio.18.Release / .Preview channel IDs
+        /// even though marketing/bootstrapper paths use Stable / Insiders.
+        /// </summary>
         public static Channel? GetChannel(this VisualStudioInstance vsInstance)
             => vsInstance.ChannelId switch
             {
-                "VisualStudio.16.Release" => Channel.Release,
-                "VisualStudio.16.Preview" => Channel.Preview,
-                "VisualStudio.16.IntPreview" => Channel.IntPreview,
-                "VisualStudio.16.int.main" => Channel.Main,
-                "VisualStudio.17.Release" => Channel.Release,
-                "VisualStudio.17.Preview" => Channel.Preview,
-                "VisualStudio.17.IntPreview" => Channel.IntPreview,
-                "VisualStudio.17.int.main" => Channel.Main,
-                "VisualStudio.18.Release" => Channel.Release,
-                "VisualStudio.18.Preview" => Channel.Preview,
+                "VisualStudio.18.Release" => Channel.Stable,
+                "VisualStudio.18.Preview" => Channel.Insiders,
                 "VisualStudio.18.IntPreview" => Channel.IntPreview,
                 "VisualStudio.18.int.main" => Channel.Main,
                 _ => null,


### PR DESCRIPTION
## Summary
- Resolve latest VS major from the `aka.ms/vs/stable` bootstrapper redirect (fallback `18`)
- Map channels to VS 2026 paths: Stable → `stable`, Insiders → `insiders` (keep `release`/`preview` as hidden aliases)
- Install under `%ProgramFiles%\Microsoft Visual Studio\{major}\{Sku}`
- Drop 16/17/2019/2022 install path logic and docs scraping via Devlooped.Web

## Test plan
- [x] Unit tests pass (177)
- [ ] CI green
- [ ] Manual: `vs install --stable --sku:build` downloads `https://aka.ms/vs/18/stable/vs_buildtools.exe`
- [ ] Manual: `vs install --rel --sku:build` still works via hidden alias