### PR TITLE
Rename package id to vs and document dnx usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,22 +1,22 @@
-![Icon](https://raw.githubusercontent.com/devlooped/dotnet-vs/main/docs/img/icon-32.png) dotnet-vs
+![Icon](https://raw.githubusercontent.com/devlooped/dotnet-vs/main/docs/img/icon-32.png) vs
 ============
 
-[![Version](https://img.shields.io/nuget/v/dotnet-vs.svg?color=royalblue)](https://www.nuget.org/packages/dotnet-vs)
-[![Downloads](https://img.shields.io/nuget/dt/dotnet-vs.svg?color=darkmagenta)](https://www.nuget.org/packages/dotnet-vs)
+[![Version](https://img.shields.io/nuget/v/vs.svg?color=royalblue)](https://www.nuget.org/packages/vs)
+[![Downloads](https://img.shields.io/nuget/dt/vs.svg?color=darkmagenta)](https://www.nuget.org/packages/vs)
 [![License](https://img.shields.io/github/license/devlooped/dotnet-vs.svg?color=blue)](https://github.com/devlooped/dotnet-vs/blob/master/license.txt)
 [![CI Status](https://github.com/devlooped/dotnet-vs/workflows/build/badge.svg?branch=main)](https://github.com/devlooped/dotnet-vs/actions?query=branch%3Amain+workflow%3Abuild+)
-[![CI Version](https://img.shields.io/endpoint?label=nuget.ci&color=brightgreen&url=https://shields.kzu.app/vpre/dotnet-vs/main)](https://pkg.kzu.app/index.json)
+[![CI Version](https://img.shields.io/endpoint?label=nuget.ci&color=brightgreen&url=https://shields.kzu.app/vpre/vs/main)](https://pkg.kzu.app/index.json)
 
-Installing or updating (same command for both):
+Run with:
 
 ```
-dotnet tool update -g dotnet-vs
+dnx vs -- [command] [options]
 ```
 
 To get the CI version:
 
 ```
-dotnet tool update -g dotnet-vs --no-cache --add-source https://pkg.kzu.app/index.json
+dnx vs --prerelease --add-source https://pkg.kzu.app/index.json -- [command] [options]
 ```
 
 <!-- #content -->
@@ -33,7 +33,7 @@ Supported commands:
 Shows the list of saved aliases
 
 ```
-Usage: vs alias [options]
+Usage: dnx vs -- alias [options]
 ```
 
 All built-in commands support a `-save:[alias]` option that will cause 
@@ -46,10 +46,10 @@ Examples:
 <!-- EXAMPLES_BEGIN -->
 ```
 # Save the first VS enterprise with the Maui/Mobile workload as the "mobile" alias
-> vs -sku:ent -first +mobile -save:mobile
+> dnx vs -- -sku:ent -first +mobile -save:mobile
 
 # Runs the saved alias with all the original arguments
-> vs mobile
+> dnx vs -- mobile
 ```
 <!-- EXAMPLES_END -->
 
@@ -58,7 +58,7 @@ Examples:
 Launches Visual Studio in client mode
 
 ```
-Usage: vs client [options]
+Usage: dnx vs -- client [options]
 ```
 
 |Option|Description|
@@ -78,7 +78,7 @@ Usage: vs client [options]
 Opens the config folder.
 
 ```
-Usage: vs config [options]
+Usage: dnx vs -- config [options]
 ```
 
 |Option|Description|
@@ -97,7 +97,7 @@ Usage: vs config [options]
 Installs a specific edition of Visual Studio.
 
 ```
-Usage: vs install [options]
+Usage: dnx vs -- install [options]
 ```
 
 |Option|Description|
@@ -125,11 +125,11 @@ Examples:
 ```
 # Installs VS enterprise with the Maui/Mobile workload
 # Note the -sku: switch/prefix is optional
-> vs install Enterprise +mobile
+> dnx vs -- install Enterprise +mobile
 
 # Install VS community with the .NET Core, ASP.NET and Azure workloads, 
 # shows installation progress and waits for it to finish before returning
-> vs install +core +web +azure
+> dnx vs -- install +core +web +azure
 ```
 <!-- EXAMPLES_END -->
 
@@ -138,7 +138,7 @@ Examples:
 Kills running devenv processes.
 
 ```
-Usage: vs kill [options]
+Usage: dnx vs -- kill [options]
 ```
 
 |Option|Description|
@@ -158,7 +158,7 @@ Examples:
 <!-- EXAMPLES_BEGIN -->
 ```
 # Kill all running instances of Visual Studio
-> vs kill all
+> dnx vs -- kill all
 ```
 <!-- EXAMPLES_END -->
 
@@ -167,7 +167,7 @@ Examples:
 Opens the folder containing the Activity.log file.
 
 ```
-Usage: vs log [options]
+Usage: dnx vs -- log [options]
 ```
 
 |Option|Description|
@@ -186,7 +186,7 @@ Usage: vs log [options]
 Modifies an installation of Visual Studio.
 
 ```
-Usage: vs modify [options]
+Usage: dnx vs -- modify [options]
 ```
 
 |Option|Description|
@@ -209,7 +209,7 @@ Examples:
 <!-- EXAMPLES_BEGIN -->
 ```
 # Add .NET Core Workload to installed Visual Studio Preview
-> vs modify insiders +core
+> dnx vs -- modify insiders +core
 ```
 <!-- EXAMPLES_END -->
 
@@ -218,7 +218,7 @@ Examples:
 This is default command, so typically it does not need to be provided as an argument.
 
 ```
-Usage: vs run [options]
+Usage: dnx vs -- run [options]
 ```
 
 |Option|Description|
@@ -242,7 +242,7 @@ All [workload switches](#workload-id-switches) are available too to filter the
 instance to run, including using the `+` prefix/alias syntax.
 
 This command will remember the last VS that was located and run. So the next time you 
-can just run the same instance by simply using `vs` (since `run` is the default command 
+can just run the same instance by simply using `dnx vs` (since `run` is the default command 
 and can be omitted).
 
 Examples:
@@ -250,16 +250,16 @@ Examples:
 <!-- EXAMPLES_BEGIN -->
 ```
 # Runs the first VS enterprise with the Maui/Mobile workload
-> vs -sku:ent -first +mobile
+> dnx vs -- -sku:ent -first +mobile
 
 # Runs VS 18.7
-> vs -v:18.7
+> dnx vs -- -v:18.7
 
 # Runs VS 18 Insiders
-> vs -v:18 -insiders
+> dnx vs -- -v:18 -insiders
 
 # Runs the last VS that was run
-> vs
+> dnx vs
 ```
 <!-- EXAMPLES_END -->
 
@@ -268,7 +268,7 @@ Examples:
 Updates an installation of Visual Studio.
 
 ```
-Usage: vs update [options]
+Usage: dnx vs -- update [options]
 ```
 
 |Option|Description|
@@ -287,7 +287,7 @@ Usage: vs update [options]
 Locates the installed version(s) of Visual Studio that satisfy the requested requirements, optionally retrieving installation properties from it.
 
 ```
-Usage: vs where [options]
+Usage: dnx vs -- where [options]
 ```
 
 |Option|Description|
@@ -355,8 +355,8 @@ See also [vswhere on GitHub](https://github.com/microsoft/vswhere).
 
 ## Workload ID switches
 
-For commands that receive workload ID switches (i.e. `vs where -requires [WORKLOAD_ID]` or 
-`vs install --add [WORKLOAD_ID]`), the following aliases are available:
+For commands that receive workload ID switches (i.e. `dnx vs -- where -requires [WORKLOAD_ID]` or 
+`dnx vs -- install --add [WORKLOAD_ID]`), the following aliases are available:
 
 |  Alias    | Workload ID |
 |-----------|----------------------------|
@@ -380,7 +380,7 @@ For commands that receive workload ID switches (i.e. `vs where -requires [WORKLO
 The aliases are converted to the appropriate switch automatically, such as into 
 `-requires [ID]` or `--add [ID]`. Additionally, depending on the command being run, 
 the aliases might use a `+` prefix (like `+mobile`), which might make for a more 
-intuitive command line, such as `vs install +mobile -sku:enterprise` or `vs +mobile` 
+intuitive command line, such as `dnx vs -- install +mobile -sku:enterprise` or `dnx vs -- +mobile` 
 (runs the VS with the mobile workload installed). The *modify* command uses `+` and `-` 
 prefix to add or remove workloads respectively, for example.
 

--- a/src/Directory.props
+++ b/src/Directory.props
@@ -2,7 +2,7 @@
   <!-- Extends Directory.Build.props -->
 
   <PropertyGroup Label="Build">
-    <Product>dotnet-vs</Product>
+    <Product>dotnet vs</Product>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     
     <!-- Until we can fix the large number of warnings -->

--- a/src/VisualStudio.Tests/Commands/GenerateReadmeCommandTests.cs
+++ b/src/VisualStudio.Tests/Commands/GenerateReadmeCommandTests.cs
@@ -62,7 +62,7 @@ namespace Devlooped.Tests
             var actual = File.ReadAllText(outputFile);
             Assert.Contains("## test", actual);
             Assert.Contains("test command description", actual);
-            Assert.Contains("Usage: vs test [options]", actual);
+            Assert.Contains("Usage: dnx vs -- test [options]", actual);
             Assert.Contains("|Option|Description|", actual);
             Assert.Contains("arg", actual);
             Assert.Contains("any of `x \\| y \\| z`", actual);

--- a/src/VisualStudio/Commands/GenerateReadmeCommand.cs
+++ b/src/VisualStudio/Commands/GenerateReadmeCommand.cs
@@ -60,7 +60,7 @@ class GenerateReadmeCommand : Command
                 var content = (await ReadCommandTemplateContentAsync(command.Name))
                     .Replace("{CommandName}", command.Name)
                     .Replace("{Description}", command.Description)
-                    .Replace("{Usage}", $"Usage: {ThisAssembly.Project.AssemblyName} {command.Name} [options]")
+                    .Replace("{Usage}", $"Usage: dnx {ThisAssembly.Project.AssemblyName} -- {command.Name} [options]")
                     .Replace("{Options}", commandOptions.ToString());
 
                 commandsBuilder.AppendLine();

--- a/src/VisualStudio/Commands/UpdateSelfCommand.cs
+++ b/src/VisualStudio/Commands/UpdateSelfCommand.cs
@@ -8,7 +8,7 @@ namespace Devlooped;
 class UpdateSelfCommand : Command
 {
     public UpdateSelfCommand()
-        : base(Commands.System.UpdateSelf, "Updates the dotnet-vs tool itself")
+        : base(Commands.System.UpdateSelf, "Updates the vs tool itself")
     {
         Hidden = true;
 
@@ -24,10 +24,10 @@ class UpdateSelfCommand : Command
         Process.Start(
             new ProcessStartInfo("dotnet")
             {
-                ArgumentList = { "tool", "update", "-g", "dotnet-vs" }
+                ArgumentList = { "tool", "update", "-g", "vs" }
             });
 
-        output.WriteLine("Running \"dotnet tool update -g dotnet-vs\"...");
+        output.WriteLine("Running \"dotnet tool update -g vs\"...");
         output.WriteLine("dotnet will continue running in background");
     }
 }

--- a/src/VisualStudio/Docs/alias.md
+++ b/src/VisualStudio/Docs/alias.md
@@ -1,4 +1,4 @@
-﻿## alias
+## alias
 
 {Description}
 
@@ -16,9 +16,9 @@ Examples:
 <!-- EXAMPLES_BEGIN -->
 ```
 # Save the first VS enterprise with the Maui/Mobile workload as the "mobile" alias
-> vs -sku:ent -first +mobile -save:mobile
+> dnx vs -- -sku:ent -first +mobile -save:mobile
 
 # Runs the saved alias with all the original arguments
-> vs mobile
+> dnx vs -- mobile
 ```
 <!-- EXAMPLES_END -->

--- a/src/VisualStudio/Docs/install.md
+++ b/src/VisualStudio/Docs/install.md
@@ -1,4 +1,4 @@
-﻿## install
+## install
 
 {Description}
 
@@ -22,10 +22,10 @@ Examples:
 ```
 # Installs VS enterprise with the Maui/Mobile workload
 # Note the -sku: switch/prefix is optional
-> vs install Enterprise +mobile
+> dnx vs -- install Enterprise +mobile
 
 # Install VS community with the .NET Core, ASP.NET and Azure workloads, 
 # shows installation progress and waits for it to finish before returning
-> vs install +core +web +azure
+> dnx vs -- install +core +web +azure
 ```
 <!-- EXAMPLES_END -->

--- a/src/VisualStudio/Docs/kill.md
+++ b/src/VisualStudio/Docs/kill.md
@@ -1,4 +1,4 @@
-﻿## kill
+## kill
 
 {Description}
 
@@ -13,6 +13,6 @@ Examples:
 <!-- EXAMPLES_BEGIN -->
 ```
 # Kill all running instances of Visual Studio
-> vs kill all
+> dnx vs -- kill all
 ```
 <!-- EXAMPLES_END -->

--- a/src/VisualStudio/Docs/modify.md
+++ b/src/VisualStudio/Docs/modify.md
@@ -1,4 +1,4 @@
-﻿## modify
+## modify
 
 {Description}
 
@@ -16,6 +16,6 @@ Examples:
 <!-- EXAMPLES_BEGIN -->
 ```
 # Add .NET Core Workload to installed Visual Studio Preview
-> vs modify insiders +core
+> dnx vs -- modify insiders +core
 ```
 <!-- EXAMPLES_END -->

--- a/src/VisualStudio/Docs/readme.md
+++ b/src/VisualStudio/Docs/readme.md
@@ -1,23 +1,23 @@
-<h1 id="dotnet-vs"><img src="https://raw.githubusercontent.com/devlooped/dotnet-vs/main/docs/img/icon.svg" alt="icon" height="32" width="32" style="vertical-align: text-top; border: 0px; padding: 0px; margin: 0px">  dotnet-vs</h1>
+<h1 id="vs"><img src="https://raw.githubusercontent.com/devlooped/dotnet-vs/main/docs/img/icon.svg" alt="icon" height="32" width="32" style="vertical-align: text-top; border: 0px; padding: 0px; margin: 0px">  vs</h1>
 
 A global tool for running, managing and querying Visual Studio installations
 
-[![Version](https://img.shields.io/nuget/v/dotnet-vs.svg?color=royalblue)](https://www.nuget.org/packages/dotnet-vs)
-[![Downloads](https://img.shields.io/nuget/dt/dotnet-vs.svg?color=darkmagenta)](https://www.nuget.org/packages/dotnet-vs)
+[![Version](https://img.shields.io/nuget/v/vs.svg?color=royalblue)](https://www.nuget.org/packages/vs)
+[![Downloads](https://img.shields.io/nuget/dt/vs.svg?color=darkmagenta)](https://www.nuget.org/packages/vs)
 [![License](https://img.shields.io/github/license/devlooped/dotnet-vs.svg?color=blue)](https://github.com/devlooped/dotnet-vs/blob/master/license.txt)
 [![CI Status](https://github.com/devlooped/dotnet-vs/workflows/build/badge.svg?branch=main)](https://github.com/devlooped/dotnet-vs/actions?query=branch%3Amain+workflow%3Abuild+)
-[![CI Version](https://img.shields.io/endpoint?label=nuget.ci&color=brightgreen&url=https://shields.kzu.app/vpre/dotnet-vs/main)](https://pkg.kzu.app/index.json)
+[![CI Version](https://img.shields.io/endpoint?label=nuget.ci&color=brightgreen&url=https://shields.kzu.app/vpre/vs/main)](https://pkg.kzu.app/index.json)
 
-Installing or updating (same command for both):
+Run with:
 
 ```
-dotnet tool update -g dotnet-vs
+dnx vs -- [command] [options]
 ```
 
 To get the CI version:
 
 ```
-dotnet tool update -g dotnet-vs --no-cache --add-source https://pkg.kzu.app/index.json
+dnx vs --prerelease --add-source https://pkg.kzu.app/index.json -- [command] [options]
 ```
 
 Command line parsing is done with [System.CommandLine](https://www.nuget.org/packages/System.CommandLine),
@@ -30,8 +30,8 @@ Supported commands:
 
 ## Workload ID switches
 
-For commands that receive workload ID switches (i.e. `vs where -requires [WORKLOAD_ID]` or 
-`vs install --add [WORKLOAD_ID]`), the following aliases are available:
+For commands that receive workload ID switches (i.e. `dnx vs -- where -requires [WORKLOAD_ID]` or 
+`dnx vs -- install --add [WORKLOAD_ID]`), the following aliases are available:
 
 |  Alias    | Workload ID |
 |-----------|----------------------------|
@@ -55,7 +55,7 @@ For commands that receive workload ID switches (i.e. `vs where -requires [WORKLO
 The aliases are converted to the appropriate switch automatically, such as into 
 `-requires [ID]` or `--add [ID]`. Additionally, depending on the command being run, 
 the aliases might use a `+` prefix (like `+mobile`), which might make for a more 
-intuitive command line, such as `vs install +mobile -sku:enterprise` or `vs +mobile` 
+intuitive command line, such as `dnx vs -- install +mobile -sku:enterprise` or `dnx vs -- +mobile` 
 (runs the VS with the mobile workload installed). The *modify* command uses `+` and `-` 
 prefix to add or remove workloads respectively, for example.
 

--- a/src/VisualStudio/Docs/run.md
+++ b/src/VisualStudio/Docs/run.md
@@ -1,4 +1,4 @@
-﻿## run
+## run
 
 {Description}
 
@@ -12,7 +12,7 @@ All [workload switches](#workload-id-switches) are available too to filter the
 instance to run, including using the `+` prefix/alias syntax.
 
 This command will remember the last VS that was located and run. So the next time you 
-can just run the same instance by simply using `vs` (since `run` is the default command 
+can just run the same instance by simply using `dnx vs` (since `run` is the default command 
 and can be omitted).
 
 Examples:
@@ -20,15 +20,15 @@ Examples:
 <!-- EXAMPLES_BEGIN -->
 ```
 # Runs the first VS enterprise with the Maui/Mobile workload
-> vs -sku:ent -first +mobile
+> dnx vs -- -sku:ent -first +mobile
 
 # Runs VS 18.7
-> vs -v:18.7
+> dnx vs -- -v:18.7
 
 # Runs VS 18 Insiders
-> vs -v:18 -insiders
+> dnx vs -- -v:18 -insiders
 
 # Runs the last VS that was run
-> vs
+> dnx vs
 ```
 <!-- EXAMPLES_END -->

--- a/src/VisualStudio/Program.cs
+++ b/src/VisualStudio/Program.cs
@@ -110,7 +110,7 @@ class Program
     protected virtual void ShowUsage()
     {
         output.WriteLine();
-        output.WriteLine($"Usage: {ThisAssembly.Project.AssemblyName} [command] [options|-?|-h|--help] [--save=ALIAS[--global]]");
+        output.WriteLine($"Usage: dnx {ThisAssembly.Project.AssemblyName} -- [command] [options|-?|-h|--help] [--save=ALIAS[--global]]");
         output.WriteLine();
         output.WriteLine("Supported commands:");
 

--- a/src/VisualStudio/VersionChecker.cs
+++ b/src/VisualStudio/VersionChecker.cs
@@ -60,7 +60,7 @@ namespace Devlooped
                 // Couldn't check latest version for some reason
                 output.WriteLine($"Latest version at {repositoryUrl}/releases/latest");
             else if (latestVersion > currentVersion)
-                output.WriteLine($"New version {latestVersion} is available. Run '{ThisAssembly.Project.AssemblyName} update-self' to update. See {repositoryUrl}/releases/tag/v{latestVersion}");
+                output.WriteLine($"New version {latestVersion} is available. Run 'dnx {ThisAssembly.Project.AssemblyName} -- update-self' to update. See {repositoryUrl}/releases/tag/v{latestVersion}");
             else if (currentVersion == developmentVersion)
                 output.WriteLine($"Latest version {latestVersion} is available at {repositoryUrl}/releases/tag/v{latestVersion}");
 
@@ -79,7 +79,7 @@ namespace Devlooped
                 latestVersion != developmentVersion &&
                 latestVersion > currentVersion)
             {
-                output.WriteLine($"New version {latestVersion} is available. Run '{ThisAssembly.Project.AssemblyName} update-self' to update. See {repositoryUrl}/releases/tag/v{latestVersion}");
+                output.WriteLine($"New version {latestVersion} is available. Run 'dnx {ThisAssembly.Project.AssemblyName} -- update-self' to update. See {repositoryUrl}/releases/tag/v{latestVersion}");
             }
         }
 

--- a/src/VisualStudio/VisualStudio.csproj
+++ b/src/VisualStudio/VisualStudio.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>A global tool for managing Visual Studio installations
 
-Usage: vs [command] [options|-?|-h|--help] [--save=ALIAS [--global]]
+Usage: dnx vs -- [command] [options|-?|-h|--help] [--save=ALIAS [--global]]
 
 Supported commands:
   alias       Shows the list of saved aliases
@@ -30,7 +30,7 @@ See full documentation at $(PackageProjectUrl).
     <AssemblyName>vs</AssemblyName>
     <RootNamespace>VisualStudio</RootNamespace>
 
-    <PackageId>dotnet-vs</PackageId>
+    <PackageId>vs</PackageId>
     <PackageReadmeFile>readme.md</PackageReadmeFile>
 
     <ToolCommandName>vs</ToolCommandName> 


### PR DESCRIPTION
## Summary
- Change NuGet package id from `dotnet-vs` to `vs` (product name and badges updated accordingly).
- Document and generate usage as `dnx vs -- [args]` across help, readme, docs, and version-check messages.
- Point `update-self` at the new package id (`dotnet tool update -g vs`).

## Test plan
- [x] `dotnet build` succeeds
- [x] All 177 unit tests pass
- [x] Package packs as `vs.*.nupkg`
- [ ] CI green on PR