### PR TITLE
Add legacy dotnet-vs package pointing users to dnx vs

### DIFF
--- a/VisualStudio.sln
+++ b/VisualStudio.sln
@@ -18,23 +18,62 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VisualStudio.Tests", "src\VisualStudio.Tests\VisualStudio.Tests.csproj", "{D379D36D-60D5-4CB4-B34C-B86FF9E3F956}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dotnet-vs", "src\dotnet-vs\dotnet-vs.csproj", "{1D7E318C-D0F5-4713-A793-EE38AC2FDF00}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8CBD9F8C-F635-4E55-A593-91FFDB2312AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8CBD9F8C-F635-4E55-A593-91FFDB2312AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8CBD9F8C-F635-4E55-A593-91FFDB2312AF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8CBD9F8C-F635-4E55-A593-91FFDB2312AF}.Debug|x64.Build.0 = Debug|Any CPU
+		{8CBD9F8C-F635-4E55-A593-91FFDB2312AF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8CBD9F8C-F635-4E55-A593-91FFDB2312AF}.Debug|x86.Build.0 = Debug|Any CPU
 		{8CBD9F8C-F635-4E55-A593-91FFDB2312AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8CBD9F8C-F635-4E55-A593-91FFDB2312AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8CBD9F8C-F635-4E55-A593-91FFDB2312AF}.Release|x64.ActiveCfg = Release|Any CPU
+		{8CBD9F8C-F635-4E55-A593-91FFDB2312AF}.Release|x64.Build.0 = Release|Any CPU
+		{8CBD9F8C-F635-4E55-A593-91FFDB2312AF}.Release|x86.ActiveCfg = Release|Any CPU
+		{8CBD9F8C-F635-4E55-A593-91FFDB2312AF}.Release|x86.Build.0 = Release|Any CPU
 		{D379D36D-60D5-4CB4-B34C-B86FF9E3F956}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D379D36D-60D5-4CB4-B34C-B86FF9E3F956}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D379D36D-60D5-4CB4-B34C-B86FF9E3F956}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D379D36D-60D5-4CB4-B34C-B86FF9E3F956}.Debug|x64.Build.0 = Debug|Any CPU
+		{D379D36D-60D5-4CB4-B34C-B86FF9E3F956}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D379D36D-60D5-4CB4-B34C-B86FF9E3F956}.Debug|x86.Build.0 = Debug|Any CPU
 		{D379D36D-60D5-4CB4-B34C-B86FF9E3F956}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D379D36D-60D5-4CB4-B34C-B86FF9E3F956}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D379D36D-60D5-4CB4-B34C-B86FF9E3F956}.Release|x64.ActiveCfg = Release|Any CPU
+		{D379D36D-60D5-4CB4-B34C-B86FF9E3F956}.Release|x64.Build.0 = Release|Any CPU
+		{D379D36D-60D5-4CB4-B34C-B86FF9E3F956}.Release|x86.ActiveCfg = Release|Any CPU
+		{D379D36D-60D5-4CB4-B34C-B86FF9E3F956}.Release|x86.Build.0 = Release|Any CPU
+		{1D7E318C-D0F5-4713-A793-EE38AC2FDF00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D7E318C-D0F5-4713-A793-EE38AC2FDF00}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D7E318C-D0F5-4713-A793-EE38AC2FDF00}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1D7E318C-D0F5-4713-A793-EE38AC2FDF00}.Debug|x64.Build.0 = Debug|Any CPU
+		{1D7E318C-D0F5-4713-A793-EE38AC2FDF00}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1D7E318C-D0F5-4713-A793-EE38AC2FDF00}.Debug|x86.Build.0 = Debug|Any CPU
+		{1D7E318C-D0F5-4713-A793-EE38AC2FDF00}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D7E318C-D0F5-4713-A793-EE38AC2FDF00}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D7E318C-D0F5-4713-A793-EE38AC2FDF00}.Release|x64.ActiveCfg = Release|Any CPU
+		{1D7E318C-D0F5-4713-A793-EE38AC2FDF00}.Release|x64.Build.0 = Release|Any CPU
+		{1D7E318C-D0F5-4713-A793-EE38AC2FDF00}.Release|x86.ActiveCfg = Release|Any CPU
+		{1D7E318C-D0F5-4713-A793-EE38AC2FDF00}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{1D7E318C-D0F5-4713-A793-EE38AC2FDF00} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {19B804F2-469A-40CA-9387-C9C1F7D231E8}

--- a/src/VisualStudio/Program.cs
+++ b/src/VisualStudio/Program.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Devlooped;
 
-class Program
+partial class Program
 {
     static readonly VersionChecker versionChecker = new();
 
@@ -59,44 +59,51 @@ class Program
 
     public async Task<int> RunAsync()
     {
-        if (preprocessor.IsTopLevelHelp(args))
-        {
-            ShowUsage();
-            return 0;
-        }
-
-        if (preprocessor.IsTopLevelVersion(args))
-        {
-            await ShowVersion();
-            return 0;
-        }
-
         try
         {
-            var processed = preprocessor.Process(args);
-            var parseResult = rootCommand.Parse(processed);
-
-            var config = new InvocationConfiguration
+            if (preprocessor.IsTopLevelHelp(args))
             {
-                Output = output,
-                Error = output,
-                EnableDefaultExceptionHandler = false,
-            };
+                ShowUsage();
+                return 0;
+            }
 
-            var exitCode = await parseResult.InvokeAsync(config, cts.Token);
+            if (preprocessor.IsTopLevelVersion(args))
+            {
+                await ShowVersion();
+                return 0;
+            }
 
-            // Help / non-success: do not run version update check (matches prior behavior).
-            if (exitCode != 0 || parseResult.Action is HelpAction or ExamplesHelpAction)
-                return exitCode;
+            try
+            {
+                var processed = preprocessor.Process(args);
+                var parseResult = rootCommand.Parse(processed);
+
+                var config = new InvocationConfiguration
+                {
+                    Output = output,
+                    Error = output,
+                    EnableDefaultExceptionHandler = false,
+                };
+
+                var exitCode = await parseResult.InvokeAsync(config, cts.Token);
+
+                // Help / non-success: do not run version update check (matches prior behavior).
+                if (exitCode != 0 || parseResult.Action is HelpAction or ExamplesHelpAction)
+                    return exitCode;
+            }
+            catch (Exception ex) when (!SharedOptions.IsDebug(args))
+            {
+                output.WriteLine(ex.Message);
+                return ErrorCodes.Error;
+            }
+
+            await versionChecker.ShowUpdateAsync(output);
+            return 0;
         }
-        catch (Exception ex) when (!SharedOptions.IsDebug(args))
+        finally
         {
-            output.WriteLine(ex.Message);
-            return ErrorCodes.Error;
+            WriteLegacyMigrationNotice(output);
         }
-
-        await versionChecker.ShowUpdateAsync(output);
-        return 0;
     }
 
     protected bool NoVersionChecks
@@ -119,4 +126,9 @@ class Program
         foreach (var command in commands)
             output.WriteLine($"  {command.Name.GetNormalizedString(maxWidth)}{command.Description}");
     }
+
+    /// <summary>
+    /// Optional post-run hook implemented by the legacy <c>dotnet-vs</c> package only.
+    /// </summary>
+    partial void WriteLegacyMigrationNotice(TextWriter output);
 }

--- a/src/dotnet-vs/LegacyNotice.cs
+++ b/src/dotnet-vs/LegacyNotice.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+
+namespace Devlooped;
+
+partial class Program
+{
+    partial void WriteLegacyMigrationNotice(TextWriter output)
+    {
+        var useColor = !Console.IsOutputRedirected && ReferenceEquals(output, Console.Out);
+
+        output.WriteLine();
+
+        if (useColor)
+            Console.ForegroundColor = ConsoleColor.Yellow;
+
+        output.WriteLine("⚠  Package 'dotnet-vs' is obsolete.");
+
+        if (useColor)
+            Console.ForegroundColor = ConsoleColor.Cyan;
+
+        output.WriteLine("   Use:  dnx vs -- [command] [options]");
+
+        if (useColor)
+            Console.ResetColor();
+
+        output.WriteLine();
+    }
+}

--- a/src/dotnet-vs/dotnet-vs.csproj
+++ b/src/dotnet-vs/dotnet-vs.csproj
@@ -1,0 +1,69 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>
+Legacy package id for the Visual Studio management tool.
+
+This package is obsolete. Use `dnx vs` instead.
+
+Usage: dnx vs -- [command] [options|-?|-h|--help] [--save=ALIAS [--global]]
+
+See full documentation at $(PackageProjectUrl).
+</Description>
+
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RollForward>Major</RollForward>
+
+    <AssemblyName>vs</AssemblyName>
+    <RootNamespace>VisualStudio</RootNamespace>
+
+    <PackageId>dotnet-vs</PackageId>
+    <PackageReadmeFile>readme.md</PackageReadmeFile>
+    <PackageTags>dotnet tool visualstudio vs vswhere obsolete</PackageTags>
+
+    <ToolCommandName>vs</ToolCommandName>
+    <PackAsTool>true</PackAsTool>
+
+    <NoWarn>$(NoWarn);NU5118</NoWarn>
+
+    <DateTime>$([System.DateTime]::UtcNow.ToString("yyyy-MM-dd"))</DateTime>
+
+    <!-- Avoid clashing with the main VisualStudio project intermediate/output under the same assembly name -->
+    <BaseIntermediateOutputPath>obj\</BaseIntermediateOutputPath>
+    <BaseOutputPath>bin\</BaseOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="all" />
+    <PackageReference Include="System.CommandLine" Version="2.0.9" />
+    <PackageReference Include="System.Text.Json" Version="10.0.9" />
+    <PackageReference Include="vswhere" Version="3.1.7" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly.AssemblyInfo" Version="2.1.2" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly.Project" Version="2.1.2" PrivateAssets="all" />
+    <PackageReference Include="System.Management" Version="10.0.9" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.3.0" />
+    <PackageReference Include="DotNetConfig" Version="1.2.0" />
+    <PackageReference Include="NuGetizer" Version="1.4.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\VisualStudio\**\*.cs"
+             Exclude="..\VisualStudio\obj\**;..\VisualStudio\bin\**"
+             Link="%(RecursiveDir)%(Filename)%(Extension)" />
+    <EmbeddedResource Include="..\VisualStudio\Docs\*.md" Link="Docs\%(Filename)%(Extension)" />
+    <None Condition="'$(TargetFramework)' != ''"
+          Include="$(VSWhereDir)vswhere.exe"
+          Link="%(Filename)%(Extension)"
+          CopyToOutputDirectory="PreserveNewest"
+          Pack="true"
+          PackagePath="tools\$(TargetFramework)\any\%(Filename)%(Extension)" />
+    <None Include="readme.md" PackagePath="readme.md" Pack="true" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectProperty Include="DateTime" />
+    <ProjectProperty Include="RepositoryUrl" />
+  </ItemGroup>
+
+</Project>

--- a/src/dotnet-vs/readme.md
+++ b/src/dotnet-vs/readme.md
@@ -1,0 +1,80 @@
+![Icon](https://raw.githubusercontent.com/devlooped/dotnet-vs/main/docs/img/icon-32.png) dotnet-vs
+============
+
+[![Version](https://img.shields.io/nuget/v/dotnet-vs.svg?color=royalblue)](https://www.nuget.org/packages/dotnet-vs)
+[![Downloads](https://img.shields.io/nuget/dt/dotnet-vs.svg?color=darkmagenta)](https://www.nuget.org/packages/dotnet-vs)
+[![License](https://img.shields.io/github/license/devlooped/dotnet-vs.svg?color=blue)](https://github.com/devlooped/dotnet-vs/blob/master/license.txt)
+[![CI Status](https://github.com/devlooped/dotnet-vs/workflows/build/badge.svg?branch=main)](https://github.com/devlooped/dotnet-vs/actions?query=branch%3Amain+workflow%3Abuild+)
+[![CI Version](https://img.shields.io/endpoint?label=nuget.ci&color=brightgreen&url=https://shields.kzu.app/vpre/dotnet-vs/main)](https://pkg.kzu.app/index.json)
+
+> [!IMPORTANT]
+> This package is obsolete. Use `dnx vs` instead.
+
+This package id (`dotnet-vs`) is retained only for compatibility with existing
+`dotnet tool install -g dotnet-vs` installs. Prefer the `vs` package and run:
+
+```
+dnx vs -- [command] [options]
+```
+
+To get the CI version:
+
+```
+dnx vs --prerelease --source https://pkg.kzu.app/index.json -- [command] [options]
+```
+
+See the full documentation at [clarius.org/dotnet-vs](https://clarius.org/dotnet-vs).
+
+---
+<!-- include https://github.com/devlooped/.github/raw/main/osmf.md -->
+## Open Source Maintenance Fee
+
+To ensure the long-term sustainability of this project, users of this package who generate 
+revenue must pay an [Open Source Maintenance Fee](https://opensourcemaintenancefee.org). 
+While the source code is freely available under the terms of the [License](https://github.com/devlooped/dotnet-vs/blob/main/license.txt), 
+this package and other aspects of the project require [adherence to the Maintenance Fee](https://github.com/devlooped/dotnet-vs/blob/main/osmfeula.txt).
+
+To pay the Maintenance Fee, [become a Sponsor](https://github.com/sponsors/devlooped) at the proper 
+OSMF tier. A single fee covers all of [Devlooped packages](https://www.nuget.org/profiles/Devlooped).
+
+<!-- https://github.com/devlooped/.github/raw/main/osmf.md -->
+---
+<!-- include https://github.com/devlooped/sponsors/raw/main/footer.md -->
+# Sponsors 
+
+<!-- sponsors.md -->
+[![Clarius Org](https://avatars.githubusercontent.com/u/71888636?v=4&s=39 "Clarius Org")](https://github.com/clarius)
+[![MFB Technologies, Inc.](https://avatars.githubusercontent.com/u/87181630?v=4&s=39 "MFB Technologies, Inc.")](https://github.com/MFB-Technologies-Inc)
+[![SandRock](https://avatars.githubusercontent.com/u/321868?u=99e50a714276c43ae820632f1da88cb71632ec97&v=4&s=39 "SandRock")](https://github.com/sandrock)
+[![DRIVE.NET, Inc.](https://avatars.githubusercontent.com/u/15047123?v=4&s=39 "DRIVE.NET, Inc.")](https://github.com/drivenet)
+[![Keith Pickford](https://avatars.githubusercontent.com/u/16598898?u=64416b80caf7092a885f60bb31612270bffc9598&v=4&s=39 "Keith Pickford")](https://github.com/Keflon)
+[![Thomas Bolon](https://avatars.githubusercontent.com/u/127185?u=7f50babfc888675e37feb80851a4e9708f573386&v=4&s=39 "Thomas Bolon")](https://github.com/tbolon)
+[![Kori Francis](https://avatars.githubusercontent.com/u/67574?u=3991fb983e1c399edf39aebc00a9f9cd425703bd&v=4&s=39 "Kori Francis")](https://github.com/kfrancis)
+[![Reuben Swartz](https://avatars.githubusercontent.com/u/724704?u=2076fe336f9f6ad678009f1595cbea434b0c5a41&v=4&s=39 "Reuben Swartz")](https://github.com/rbnswartz)
+[![Jacob Foshee](https://avatars.githubusercontent.com/u/480334?v=4&s=39 "Jacob Foshee")](https://github.com/jfoshee)
+[![](https://avatars.githubusercontent.com/u/33566379?u=bf62e2b46435a267fa246a64537870fd2449410f&v=4&s=39 "")](https://github.com/Mrxx99)
+[![Eric Johnson](https://avatars.githubusercontent.com/u/26369281?u=41b560c2bc493149b32d384b960e0948c78767ab&v=4&s=39 "Eric Johnson")](https://github.com/eajhnsn1)
+[![Jonathan ](https://avatars.githubusercontent.com/u/5510103?u=98dcfbef3f32de629d30f1f418a095bf09e14891&v=4&s=39 "Jonathan ")](https://github.com/Jonathan-Hickey)
+[![Ken Bonny](https://avatars.githubusercontent.com/u/6417376?u=569af445b6f387917029ffb5129e9cf9f6f68421&v=4&s=39 "Ken Bonny")](https://github.com/KenBonny)
+[![Simon Cropp](https://avatars.githubusercontent.com/u/122666?v=4&s=39 "Simon Cropp")](https://github.com/SimonCropp)
+[![agileworks-eu](https://avatars.githubusercontent.com/u/5989304?v=4&s=39 "agileworks-eu")](https://github.com/agileworks-eu)
+[![Zheyu Shen](https://avatars.githubusercontent.com/u/4067473?v=4&s=39 "Zheyu Shen")](https://github.com/arsdragonfly)
+[![Vezel](https://avatars.githubusercontent.com/u/87844133?v=4&s=39 "Vezel")](https://github.com/vezel-dev)
+[![ChilliCream](https://avatars.githubusercontent.com/u/16239022?v=4&s=39 "ChilliCream")](https://github.com/ChilliCream)
+[![4OTC](https://avatars.githubusercontent.com/u/68428092?v=4&s=39 "4OTC")](https://github.com/4OTC)
+[![domischell](https://avatars.githubusercontent.com/u/66068846?u=0a5c5e2e7d90f15ea657bc660f175605935c5bea&v=4&s=39 "domischell")](https://github.com/DominicSchell)
+[![Adrian Alonso](https://avatars.githubusercontent.com/u/2027083?u=129cf516d99f5cb2fd0f4a0787a069f3446b7522&v=4&s=39 "Adrian Alonso")](https://github.com/adalon)
+[![torutek](https://avatars.githubusercontent.com/u/33917059?v=4&s=39 "torutek")](https://github.com/torutek)
+[![Ryan McCaffery](https://avatars.githubusercontent.com/u/16667079?u=c0daa64bb5c1b572130e05ae2b6f609ecc912d4d&v=4&s=39 "Ryan McCaffery")](https://github.com/mccaffers)
+[![Seika Logiciel](https://avatars.githubusercontent.com/u/2564602?v=4&s=39 "Seika Logiciel")](https://github.com/SeikaLogiciel)
+[![Andrew Grant](https://avatars.githubusercontent.com/devlooped-user?s=39 "Andrew Grant")](https://github.com/wizardness)
+[![eska-gmbh](https://avatars.githubusercontent.com/devlooped-team?s=39 "eska-gmbh")](https://github.com/eska-gmbh)
+[![Geodata AS](https://avatars.githubusercontent.com/u/5946299?v=4&s=39 "Geodata AS")](https://github.com/geodata-no)
+
+
+<!-- sponsors.md -->
+[![Sponsor this project](https://avatars.githubusercontent.com/devlooped-sponsor?s=118 "Sponsor this project")](https://github.com/sponsors/devlooped)
+
+[Learn more about GitHub Sponsors](https://github.com/sponsors)
+
+<!-- https://github.com/devlooped/sponsors/raw/main/footer.md -->


### PR DESCRIPTION
## Summary
- Add a NuGetizer-powered legacy `dotnet-vs` tool package that source-links `src/VisualStudio` so existing `dotnet tool install -g dotnet-vs` installs keep working.
- After every run of the legacy tool, print a colorful notice steering users to `dnx vs`.
- Package readme includes header badges, a `> [!IMPORTANT]` obsolete callout, OSMF, and sponsors footer.

## Test plan
- [x] `dotnet build VisualStudio.sln`
- [x] `dotnet test` (177 passed)
- [x] `dotnet pack src/dotnet-vs` produces `dotnet-vs.*.nupkg` with tool assets + readme
- [x] Legacy tool shows migration notice; main `vs` package does not