### PR TITLE
Use NuGet.Versioning for SemVer-aware version checks

### DIFF
--- a/src/VisualStudio.Tests/VersionCheckerTests.cs
+++ b/src/VisualStudio.Tests/VersionCheckerTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.IO;
-using System.Reflection;
 using System.Threading.Tasks;
 using DotNetConfig;
+using NuGet.Versioning;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -20,8 +20,8 @@ namespace Devlooped.Tests
             var writer = new StringWriter();
             var config = Config.Build(Path.GetTempFileName());
 
-            await new VersionChecker(new Version(42, 42, 42, 0), config).ShowVersionAsync(writer);
-            await new VersionChecker(new Version(1, 0, 5), config).ShowVersionAsync(writer);
+            await new VersionChecker(new NuGetVersion(42, 42, 42), config).ShowVersionAsync(writer);
+            await new VersionChecker(new NuGetVersion(1, 0, 5), config).ShowVersionAsync(writer);
 
             var output = writer.ToString().Split(writer.NewLine);
 
@@ -32,7 +32,7 @@ namespace Devlooped.Tests
         [Fact]
         public async Task when_showing_version_for_development_version_then_renders_latest_tag()
         {
-            var checker = new VersionChecker(new Version(42, 42, 42, 0), Config.Build(Path.GetTempFileName()));
+            var checker = new VersionChecker(new NuGetVersion(42, 42, 42), Config.Build(Path.GetTempFileName()));
             var writer = new StringWriter();
 
             await checker.ShowVersionAsync(writer);
@@ -43,7 +43,7 @@ namespace Devlooped.Tests
         [Fact]
         public async Task when_showing_version_for_old_version_then_renders_latest_tag()
         {
-            var checker = new VersionChecker(new Version(0, 1, 1), Config.Build(Path.GetTempFileName()));
+            var checker = new VersionChecker(new NuGetVersion(0, 1, 1), Config.Build(Path.GetTempFileName()));
             var writer = new StringWriter();
 
             await checker.ShowVersionAsync(writer);
@@ -63,7 +63,7 @@ namespace Devlooped.Tests
                 .SetString("vs", "latest", "0.1.5", ConfigLevel.Local)
                 .SetDateTime("vs", "checked", DateTime.Now - TimeSpan.FromDays(10), ConfigLevel.Local);
 
-            var checker = new VersionChecker(new Version(0, 1, 1), config);
+            var checker = new VersionChecker(new NuGetVersion(0, 1, 1), config);
 
             var writer = new StringWriter();
 
@@ -84,7 +84,7 @@ namespace Devlooped.Tests
                 .SetString("vs", "latest", "99.99.99", ConfigLevel.Local)
                 .SetDateTime("vs", "checked", (DateTime.Now - TimeSpan.FromDays(3)), ConfigLevel.Local);
 
-            var checker = new VersionChecker(new Version(0, 1, 1), config);
+            var checker = new VersionChecker(new NuGetVersion(0, 1, 1), config);
 
             var writer = new StringWriter();
             await checker.ShowUpdateAsync(writer);
@@ -93,6 +93,32 @@ namespace Devlooped.Tests
 
             Assert.Contains(output, line => line.Contains("New version"));
             Assert.Contains(output, line => line.Contains($"{ThisAssembly.Project.RepositoryUrl}/releases/tag/v99.99.99"));
+        }
+
+        [Fact]
+        public async Task when_latest_is_prerelease_then_compares_with_semver()
+        {
+            var config = Config.Build(Path.GetTempFileName());
+            config = config
+                .SetString("vs", "latest", "2.0.0-beta", ConfigLevel.Local)
+                .SetDateTime("vs", "checked", DateTime.Now - TimeSpan.FromDays(1), ConfigLevel.Local);
+
+            // Pre-release latest is newer than an older stable
+            var writer = new StringWriter();
+            await new VersionChecker(NuGetVersion.Parse("1.0.0"), config).ShowUpdateAsync(writer);
+            Assert.Contains(writer.ToString().Split(writer.NewLine), line => line.Contains("New version 2.0.0-beta"));
+
+            // Same pre-release is not newer
+            writer = new StringWriter();
+            await new VersionChecker(NuGetVersion.Parse("2.0.0-beta"), config).ShowUpdateAsync(writer);
+            Assert.DoesNotContain(writer.ToString().Split(writer.NewLine), line => line.Contains("New version"));
+
+            // Stable release is newer than pre-release with same major.minor.patch
+            config = config.SetString("vs", "latest", "2.0.0", ConfigLevel.Local);
+            writer = new StringWriter();
+            await new VersionChecker(NuGetVersion.Parse("2.0.0-beta"), config).ShowUpdateAsync(writer);
+            Assert.Contains(writer.ToString().Split(writer.NewLine), line => line.Contains("New version 2.0.0"));
+            Assert.Contains(writer.ToString().Split(writer.NewLine), line => line.Contains("/releases/tag/v2.0.0"));
         }
     }
 }

--- a/src/VisualStudio/VersionChecker.cs
+++ b/src/VisualStudio/VersionChecker.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using DotNetConfig;
+using NuGet.Versioning;
 
 namespace Devlooped
 {
@@ -13,21 +14,23 @@ namespace Devlooped
     /// </summary>
     class VersionChecker
     {
-        static readonly Version developmentVersion = new Version(42, 42, 42, 0);
+        static readonly NuGetVersion developmentVersion = new(42, 42, 42);
 
-        readonly Version currentVersion;
+        readonly NuGetVersion currentVersion;
         readonly ConfigLevel saveLevel;
         readonly string repositoryUrl;
-        readonly Task<Version> getLatest;
+        readonly Task<NuGetVersion> getLatest;
         ConfigSection configuration;
 
         public VersionChecker()
-            : this(new Version(ThisAssembly.Info.Version), Config.Build(ConfigLevel.Global), saveLevel: ConfigLevel.Global)
+            : this(ParseVersion(ThisAssembly.Project.Version) ?? developmentVersion,
+                  Config.Build(ConfigLevel.Global),
+                  saveLevel: ConfigLevel.Global)
         {
         }
 
         // For testing
-        internal VersionChecker(Version currentVersion, Config configuration,
+        internal VersionChecker(NuGetVersion currentVersion, Config configuration,
             string section = ThisAssembly.Project.AssemblyName,
             string repositoryUrl = ThisAssembly.Project.RepositoryUrl,
             ConfigLevel saveLevel = ConfigLevel.Local)
@@ -46,7 +49,7 @@ namespace Devlooped
 
         public async Task ShowVersionAsync(TextWriter output)
         {
-            output.WriteLine($"{ThisAssembly.Project.AssemblyName} version {currentVersion.ToString(3)} ({ThisAssembly.Project.DateTime})");
+            output.WriteLine($"{ThisAssembly.Project.AssemblyName} version {currentVersion.ToNormalizedString()} ({ThisAssembly.Project.DateTime})");
 
             if (NoOp)
                 return;
@@ -60,9 +63,9 @@ namespace Devlooped
                 // Couldn't check latest version for some reason
                 output.WriteLine($"Latest version at {repositoryUrl}/releases/latest");
             else if (latestVersion > currentVersion)
-                output.WriteLine($"New version {latestVersion} is available. Run 'dnx {ThisAssembly.Project.AssemblyName} -- update-self' to update. See {repositoryUrl}/releases/tag/v{latestVersion}");
+                output.WriteLine($"New version {latestVersion.ToNormalizedString()} is available. Run 'dnx {ThisAssembly.Project.AssemblyName} -- update-self' to update. See {repositoryUrl}/releases/tag/v{latestVersion.ToNormalizedString()}");
             else if (currentVersion == developmentVersion)
-                output.WriteLine($"Latest version {latestVersion} is available at {repositoryUrl}/releases/tag/v{latestVersion}");
+                output.WriteLine($"Latest version {latestVersion.ToNormalizedString()} is available at {repositoryUrl}/releases/tag/v{latestVersion.ToNormalizedString()}");
 
             output.WriteLine();
         }
@@ -79,15 +82,15 @@ namespace Devlooped
                 latestVersion != developmentVersion &&
                 latestVersion > currentVersion)
             {
-                output.WriteLine($"New version {latestVersion} is available. Run 'dnx {ThisAssembly.Project.AssemblyName} -- update-self' to update. See {repositoryUrl}/releases/tag/v{latestVersion}");
+                output.WriteLine($"New version {latestVersion.ToNormalizedString()} is available. Run 'dnx {ThisAssembly.Project.AssemblyName} -- update-self' to update. See {repositoryUrl}/releases/tag/v{latestVersion.ToNormalizedString()}");
             }
         }
 
-        async Task<Version> GetLatestAsync()
+        async Task<NuGetVersion> GetLatestAsync()
         {
             var lastChecked = configuration.GetDateTime("checked");
             var latestSaved = configuration.GetString("latest");
-            var latestVersion = Version.TryParse(latestSaved, out var parsed) ? parsed : developmentVersion;
+            var latestVersion = ParseVersion(latestSaved) ?? developmentVersion;
 
             // We check once a week at most.
             if (lastChecked == null ||
@@ -99,15 +102,22 @@ namespace Devlooped
                 if (response.StatusCode == HttpStatusCode.Found)
                 {
                     var latestTagUrl = response.Headers.Location.ToString();
-                    latestVersion = new Version(latestTagUrl.Split('/').Last().Trim('v'));
-                    configuration = configuration
-                        .SetString("latest", latestVersion.ToString(3), saveLevel)
-                        // NOTE: we only save checked date if we succeeded at checking latest.
-                        .SetDateTime("checked", DateTime.Now, saveLevel);
+                    var tag = latestTagUrl.Split('/').Last().TrimStart('v');
+                    if (ParseVersion(tag) is NuGetVersion parsedLatest)
+                    {
+                        latestVersion = parsedLatest;
+                        configuration = configuration
+                            .SetString("latest", latestVersion.ToNormalizedString(), saveLevel)
+                            // NOTE: we only save checked date if we succeeded at checking latest.
+                            .SetDateTime("checked", DateTime.Now, saveLevel);
+                    }
                 }
             }
 
             return latestVersion;
         }
+
+        static NuGetVersion ParseVersion(string value)
+            => !string.IsNullOrEmpty(value) && NuGetVersion.TryParse(value, out var version) ? version : null;
     }
 }

--- a/src/VisualStudio/VisualStudio.csproj
+++ b/src/VisualStudio/VisualStudio.csproj
@@ -43,6 +43,7 @@ See full documentation at $(PackageProjectUrl).
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Versioning" Version="7.6.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.9" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />
     <PackageReference Include="vswhere" Version="3.1.7" PrivateAssets="all" />

--- a/src/dotnet-vs/dotnet-vs.csproj
+++ b/src/dotnet-vs/dotnet-vs.csproj
@@ -36,6 +36,7 @@ See full documentation at $(PackageProjectUrl).
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="all" />
+    <PackageReference Include="NuGet.Versioning" Version="7.6.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.9" />
     <PackageReference Include="System.Text.Json" Version="10.0.9" />
     <PackageReference Include="vswhere" Version="3.1.7" PrivateAssets="all" />


### PR DESCRIPTION
## Summary
- Switch `VersionChecker` from `System.Version` to `NuGet.Versioning` (`NuGetVersion`) so GitHub release tags with SemVer prerelease labels (e.g. `v2.0.0-beta`) parse and compare correctly.
- Persist and display normalized versions (including prerelease) so update messages and release URLs stay accurate.
- Add a SemVer unit test covering prerelease vs stable ordering.
- Fixes publish failure on the `v2.0.0-beta` release when version-check tests hit `/releases/latest`.

## Test plan
- [x] `dotnet test src/VisualStudio.Tests -c Release` (178 tests, including VersionChecker + SemVer cases)
- [ ] CI green on PR