### PR TITLE
Fix vswhere -requires switch for where/run workload filters

### DIFF
--- a/src/VisualStudio.Tests/WorkloadOptionsTests.cs
+++ b/src/VisualStudio.Tests/WorkloadOptionsTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Xunit;
 
 namespace Devlooped.Tests
@@ -56,6 +57,28 @@ namespace Devlooped.Tests
 
             Assert.Equal(parsed, string.Join(' ', removes));
             Assert.Equal(extra, string.Join(' ', leftover));
+        }
+
+        [Fact]
+        public void when_emitting_vswhere_requires_then_uses_single_dash()
+        {
+            // vswhere only accepts -requires; --requires is reported as "Unknown parameter".
+            var args = CommandHelpers.ToWorkloadArgs(
+                "requires",
+                ["Microsoft.VisualStudio.Workload.NativeDesktop"],
+                "-").ToArray();
+
+            Assert.Equal(["-requires", "Microsoft.VisualStudio.Workload.NativeDesktop"], args);
+        }
+
+        [Fact]
+        public void when_emitting_installer_add_then_uses_double_dash()
+        {
+            var args = CommandHelpers.ToWorkloadArgs(
+                "add",
+                ["Microsoft.VisualStudio.Workload.NativeDesktop"]).ToArray();
+
+            Assert.Equal(["--add", "Microsoft.VisualStudio.Workload.NativeDesktop"], args);
         }
     }
 }

--- a/src/VisualStudio/CommandHelpers.cs
+++ b/src/VisualStudio/CommandHelpers.cs
@@ -29,6 +29,11 @@ static class CommandHelpers
         return values ?? Array.Empty<string>();
     }
 
-    public static IEnumerable<string> ToWorkloadArgs(string argumentName, IEnumerable<string> ids) =>
-        ids.SelectMany(id => new[] { "--" + argumentName, id });
+    /// <param name="argumentPrefix">
+    /// Switch prefix for the underlying tool. Use <c>-</c> for vswhere (e.g. <c>-requires</c>)
+    /// and <c>--</c> for the Visual Studio installer (e.g. <c>--add</c>).
+    /// </param>
+    public static IEnumerable<string> ToWorkloadArgs(string argumentName, IEnumerable<string> ids, string argumentPrefix = "--") =>
+        ids.Where(id => !string.IsNullOrEmpty(id))
+            .SelectMany(id => new[] { argumentPrefix + argumentName, id });
 }

--- a/src/VisualStudio/Commands/RunCommand.cs
+++ b/src/VisualStudio/Commands/RunCommand.cs
@@ -114,7 +114,7 @@ class RunCommand : Command
             settings.Set<string>("devenv", null);
 
         IEnumerable<VisualStudioInstance> instances = (await whereService
-            .GetAllInstancesAsync(filter, extraArguments: CommandHelpers.ToWorkloadArgs("requires", workloads)))
+            .GetAllInstancesAsync(filter, extraArguments: CommandHelpers.ToWorkloadArgs("requires", workloads, "-")))
             .OrderByDescending(i => i.Catalog.BuildVersion);
 
         if (!string.IsNullOrEmpty(id))

--- a/src/VisualStudio/Commands/WhereCommand.cs
+++ b/src/VisualStudio/Commands/WhereCommand.cs
@@ -58,7 +58,8 @@ class WhereCommand : Command
     {
         var filter = CommandHelpers.GetFilter(parse, channelOptions, skuOption, filterOption, firstOption);
         var workloads = CommandHelpers.GetWorkloadIds(parse, requiresOption);
-        var extra = CommandHelpers.ToWorkloadArgs("requires", workloads).Concat(parse.UnmatchedTokens);
+        // vswhere only accepts single-dash switches (e.g. -requires), not --requires.
+        var extra = CommandHelpers.ToWorkloadArgs("requires", workloads, "-").Concat(parse.UnmatchedTokens);
 
         var property = parse.GetValue(propOption);
         var showList = parse.GetValue(listOption);

--- a/src/VisualStudio/WhereService.cs
+++ b/src/VisualStudio/WhereService.cs
@@ -38,7 +38,10 @@ namespace Devlooped
             };
 
             foreach (var arg in extraArguments)
-                psi.ArgumentList.Add(arg);
+            {
+                if (arg != null)
+                    psi.ArgumentList.Add(arg);
+            }
 
             var process = Process.Start(psi);
             var output = await process.StandardOutput.ReadToEndAsync();


### PR DESCRIPTION
## Summary
- Restore single-dash `-requires` when forwarding workload filters to vswhere from `where` and `run` (double-dash `--requires` is rejected as unknown).
- Keep installer paths on `--add` / `--remove`.
- Skip null args when building the vswhere process argument list; add unit tests for both switch styles.

## Test plan
- [x] `vs where +native` returns matching instances
- [x] `vs where --requires Microsoft.VisualStudio.Workload.NativeDesktop` works
- [x] `vs where +native --prop InstallationPath` works
- [x] WorkloadOptions unit tests pass