### PR TITLE
Add vc workload alias and docs link to full IDs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -368,6 +368,7 @@ For commands that receive workload ID switches (i.e. `dnx vs -- where -requires 
 | `desktop` | Microsoft.VisualStudio.Workload.ManagedDesktop |
 | `unity`   | Microsoft.VisualStudio.Workload.ManagedGame |
 | `native`  | Microsoft.VisualStudio.Workload.NativeDesktop |
+| `vc`      | Microsoft.VisualStudio.Workload.VCTools |
 | `web`     | Microsoft.VisualStudio.Workload.NetWeb |
 | `node`    | Microsoft.VisualStudio.Workload.Node |
 | `office`  | Microsoft.VisualStudio.Workload.Office |
@@ -382,6 +383,8 @@ the aliases might use a `+` prefix (like `+mobile`), which might make for a more
 intuitive command line, such as `dnx vs -- install +mobile -sku:enterprise` or `dnx vs -- +mobile` 
 (runs the VS with the mobile workload installed). The *modify* command uses `+` and `-` 
 prefix to add or remove workloads respectively, for example.
+
+See the [full list of workload and component IDs](https://aka.ms/vs/workloads).
 
 <!-- #content -->
 ---

--- a/src/VisualStudio.Tests/WorkloadOptionsTests.cs
+++ b/src/VisualStudio.Tests/WorkloadOptionsTests.cs
@@ -9,6 +9,7 @@ namespace Devlooped.Tests
         [InlineData("+", "--", "+core", "--requires Microsoft.VisualStudio.Workload.NetCoreTools", "")]
         [InlineData("+", "--", "+core +mobile", "--requires Microsoft.VisualStudio.Workload.NetCoreTools --requires Microsoft.VisualStudio.Workload.NetCrossPlat", "")]
         [InlineData("+", "--", "+core -version [\"16.8,)\"]", "--requires Microsoft.VisualStudio.Workload.NetCoreTools", "-version [\"16.8,)\"]")]
+        [InlineData("+", "--", "+vc", "--requires Microsoft.VisualStudio.Workload.VCTools", "")]
         [InlineData("+", "--", "+Microsoft.VisualStudio.SomeComponent", "--requires Microsoft.VisualStudio.SomeComponent", "")]
         [InlineData("+", "--", "-someswitch", "", "-someswitch")]
         public void when_parsing_requires_then_converts_alias_to_argument(string prefix, string argumentPrefix, string arguments, string parsed, string extra)

--- a/src/VisualStudio/Docs/readme.md
+++ b/src/VisualStudio/Docs/readme.md
@@ -46,6 +46,7 @@ For commands that receive workload ID switches (i.e. `dnx vs -- where -requires 
 | `desktop` | Microsoft.VisualStudio.Workload.ManagedDesktop |
 | `unity`   | Microsoft.VisualStudio.Workload.ManagedGame |
 | `native`  | Microsoft.VisualStudio.Workload.NativeDesktop |
+| `vc`      | Microsoft.VisualStudio.Workload.VCTools |
 | `web`     | Microsoft.VisualStudio.Workload.NetWeb |
 | `node`    | Microsoft.VisualStudio.Workload.Node |
 | `office`  | Microsoft.VisualStudio.Workload.Office |
@@ -60,6 +61,8 @@ the aliases might use a `+` prefix (like `+mobile`), which might make for a more
 intuitive command line, such as `dnx vs -- install +mobile -sku:enterprise` or `dnx vs -- +mobile` 
 (runs the VS with the mobile workload installed). The *modify* command uses `+` and `-` 
 prefix to add or remove workloads respectively, for example.
+
+See the [full list of workload and component IDs](https://aka.ms/vs/workloads).
 
 <!-- #content -->
 ---

--- a/src/VisualStudio/Parsing/WorkloadAliases.cs
+++ b/src/VisualStudio/Parsing/WorkloadAliases.cs
@@ -15,6 +15,7 @@ static class WorkloadAliases
         { "desktop", "Microsoft.VisualStudio.Workload.ManagedDesktop" },
         { "unity", "Microsoft.VisualStudio.Workload.ManagedGame" },
         { "native", "Microsoft.VisualStudio.Workload.NativeDesktop" },
+        { "vc", "Microsoft.VisualStudio.Workload.VCTools" },
         { "web", "Microsoft.VisualStudio.Workload.NetWeb" },
         { "node", "Microsoft.VisualStudio.Workload.Node" },
         { "office", "Microsoft.VisualStudio.Workload.Office" },

--- a/src/VisualStudio/readme.md
+++ b/src/VisualStudio/readme.md
@@ -352,6 +352,7 @@ For commands that receive workload ID switches (i.e. `dnx vs -- where -requires 
 | `desktop` | Microsoft.VisualStudio.Workload.ManagedDesktop |
 | `unity`   | Microsoft.VisualStudio.Workload.ManagedGame |
 | `native`  | Microsoft.VisualStudio.Workload.NativeDesktop |
+| `vc`      | Microsoft.VisualStudio.Workload.VCTools |
 | `web`     | Microsoft.VisualStudio.Workload.NetWeb |
 | `node`    | Microsoft.VisualStudio.Workload.Node |
 | `office`  | Microsoft.VisualStudio.Workload.Office |
@@ -366,6 +367,8 @@ the aliases might use a `+` prefix (like `+mobile`), which might make for a more
 intuitive command line, such as `dnx vs -- install +mobile -sku:enterprise` or `dnx vs -- +mobile` 
 (runs the VS with the mobile workload installed). The *modify* command uses `+` and `-` 
 prefix to add or remove workloads respectively, for example.
+
+See the [full list of workload and component IDs](https://aka.ms/vs/workloads).
 
 <!-- #content -->
 <!-- ../../readme.md#content -->


### PR DESCRIPTION
## Summary
- Add `vc` alias for `Microsoft.VisualStudio.Workload.VCTools` in workload token rewriting
- Document the alias and link to the full workload/component ID list at https://aka.ms/vs/workloads

## Test plan
- [x] Unit test covers `+vc` -> `--requires Microsoft.VisualStudio.Workload.VCTools`
- [ ] CI green