### PR TITLE
Add --version to install and update commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,7 @@ Usage: dnx vs -- install [options]
 | `sku` | Edition, one of `e\|ent\|enterprise`, `p\|pro\|professional`, `c\|com\|community`, `b\|build\|buildtools` or `t\|test\|testagent` |
 | `filter` | Expression to filter VS instances. E.g. `x => x.InstanceId = '123'` |
 | `nick\|nickname` | Optional nickname to use |
+| `v\|version` | Install specific (semantic) version, such as 18.7 or 18.7.3 |
 | `add` | A workload ID |
 
 
@@ -129,6 +130,12 @@ Examples:
 # Install VS community with the .NET Core, ASP.NET and Azure workloads, 
 # shows installation progress and waits for it to finish before returning
 > dnx vs -- install +core +web +azure
+
+# Install VS 18 Enterprise
+> dnx vs -- install -v:18 -sku:ent
+
+# Install the latest VS 17 (2022) Community
+> dnx vs -- install --version 17
 ```
 <!-- EXAMPLES_END -->
 
@@ -279,7 +286,20 @@ Usage: dnx vs -- update [options]
 | `filter` | Expression to filter VS instances. E.g. `x => x.InstanceId = '123'` |
 | `first` | Update first matching instance. |
 | `all` | Update all instances. |
+| `v\|version` | Update specific (semantic) version, such as 18.7 or 18.7.3 |
 
+
+Examples:
+
+<!-- EXAMPLES_BEGIN -->
+```
+# Update the installed VS 18.7 instance
+> dnx vs -- update -v:18.7
+
+# Update all matching VS 17 instances
+> dnx vs -- update --version 17 --all
+```
+<!-- EXAMPLES_END -->
 
 ## where
 

--- a/src/VisualStudio.Tests/Commands/VersionOptionTests.cs
+++ b/src/VisualStudio.Tests/Commands/VersionOptionTests.cs
@@ -1,0 +1,58 @@
+using System.CommandLine;
+using System.Linq;
+using Xunit;
+
+namespace Devlooped.Tests
+{
+    public class VersionOptionTests
+    {
+        [Theory]
+        [InlineData(Commands.Run)]
+        [InlineData(Commands.Install)]
+        [InlineData(Commands.Update)]
+        public void when_command_is_defined_then_it_accepts_version_option(string commandName)
+        {
+            var root = new VsRootCommand();
+            var command = root.Subcommands.Single(c => c.Name == commandName);
+
+            Assert.Contains(command.Options, o => o.Name == "--version" && o.Aliases.Contains("-v"));
+        }
+
+        [Theory]
+        [InlineData(Commands.Install, "--version", "18.7")]
+        [InlineData(Commands.Install, "-v", "18.7.3")]
+        [InlineData(Commands.Update, "--version", "18.7")]
+        [InlineData(Commands.Update, "-v", "17.14")]
+        [InlineData(Commands.Run, "--version", "18.7")]
+        [InlineData(Commands.Run, "-v", "18.7.3")]
+        public void when_parsing_version_then_option_is_bound_and_not_unmatched(
+            string commandName, string option, string value)
+        {
+            var root = new VsRootCommand();
+            var parse = root.Parse(new[] { commandName, option, value });
+
+            Assert.Empty(parse.Errors);
+            Assert.DoesNotContain(option, parse.UnmatchedTokens);
+            Assert.DoesNotContain(value, parse.UnmatchedTokens);
+
+            var version = parse.CommandResult.Command.Options.OfType<Option<string>>().Single(o => o.Name == "--version");
+            Assert.Equal(value, parse.GetValue(version));
+        }
+
+        [Theory]
+        [InlineData(Commands.Install, "-v:18.7", "18.7")]
+        [InlineData(Commands.Update, "--version=18.7.3", "18.7.3")]
+        [InlineData(Commands.Run, "-v:18", "18")]
+        public void when_parsing_legacy_version_syntax_then_option_is_bound(
+            string commandName, string token, string expected)
+        {
+            var rewritten = ArgumentPreprocessor.RewriteForCommand(commandName, new[] { token });
+            var root = new VsRootCommand();
+            var parse = root.Parse(new[] { commandName }.Concat(rewritten).ToArray());
+
+            Assert.Empty(parse.Errors);
+            var version = parse.CommandResult.Command.Options.OfType<Option<string>>().Single(o => o.Name == "--version");
+            Assert.Equal(expected, parse.GetValue(version));
+        }
+    }
+}

--- a/src/VisualStudio.Tests/VisualStudioOptionsTests.cs
+++ b/src/VisualStudio.Tests/VisualStudioOptionsTests.cs
@@ -18,12 +18,14 @@ namespace Devlooped.Tests
             var all = SharedOptions.AllOption("test");
             var nick = SharedOptions.NicknameOption();
             var exp = SharedOptions.ExperimentalOption("test");
+            var version = SharedOptions.VersionOption("test");
             cmd.Options.Add(sku);
             cmd.Options.Add(filter);
             cmd.Options.Add(first);
             cmd.Options.Add(all);
             cmd.Options.Add(nick);
             cmd.Options.Add(exp);
+            cmd.Options.Add(version);
             cmd.TreatUnmatchedTokensAsErrors = false;
 
             var root = new RootCommand();
@@ -49,7 +51,8 @@ namespace Devlooped.Tests
                 cmd.Options.OfType<Option<string>>().First(o => o.Name == "--sku"),
                 cmd.Options.OfType<Option<string>>().First(o => o.Name == "--filter"),
                 cmd.Options.OfType<Option<bool>>().First(o => o.Name == "--first"),
-                cmd.Options.OfType<Option<bool>>().First(o => o.Name == "--all"));
+                cmd.Options.OfType<Option<bool>>().First(o => o.Name == "--all"),
+                cmd.Options.OfType<Option<string>>().First(o => o.Name == "--version"));
         }
 
         [Theory]
@@ -185,6 +188,22 @@ namespace Devlooped.Tests
             var args = string.IsNullOrEmpty(argument) ? Array.Empty<string>() : new[] { argument };
             var filter = GetFilter(ParseSelection(args));
             Assert.Equal(expectedValue, filter.All);
+        }
+
+        [Theory]
+        [InlineData("", null)]
+        [InlineData("--version=18.7", "18.7")]
+        [InlineData("-v:18.7.3", "18.7.3")]
+        [InlineData("--version", "18")]
+        public void when_parsing_version_argument_then_version_is_set(string argument, string expectedValue)
+        {
+            var args = string.IsNullOrEmpty(argument)
+                ? Array.Empty<string>()
+                : argument == "--version"
+                    ? new[] { "--version", "18" }
+                    : new[] { argument };
+            var filter = GetFilter(ParseSelection(args));
+            Assert.Equal(expectedValue, filter.Version);
         }
 
         [Theory]

--- a/src/VisualStudio.Tests/VisualStudioPredicateBuilderTests.cs
+++ b/src/VisualStudio.Tests/VisualStudioPredicateBuilderTests.cs
@@ -63,7 +63,25 @@ namespace Devlooped.Tests
             Assert.False(predicate(new vswhere.VisualStudioInstance() { InstanceId = "123" }.WithSku(Sku.Professional).WithChannel(Channel.Stable)));
         }
 
-        static VisualStudioFilter GetFilter(Sku? sku = null, Channel? channel = null, string expression = null) =>
-            new VisualStudioFilter(Channel: channel, Sku: sku, Expression: expression);
+        [Fact]
+        public async Task when_evaluating_version_then_predicate_matches_semantic_prefix()
+        {
+            var builder = new VisualStudioPredicateBuilder();
+
+            var predicate = await builder.BuildPredicateAsync(GetFilter(version: "18.7"));
+
+            Assert.True(predicate(new vswhere.VisualStudioInstance
+            {
+                Catalog = new vswhere.VisualStudioCatalog { ProductSemanticVersion = "18.7.3" }
+            }));
+            Assert.False(predicate(new vswhere.VisualStudioInstance
+            {
+                Catalog = new vswhere.VisualStudioCatalog { ProductSemanticVersion = "18.8.0" }
+            }));
+            Assert.False(predicate(new vswhere.VisualStudioInstance()));
+        }
+
+        static VisualStudioFilter GetFilter(Sku? sku = null, Channel? channel = null, string expression = null, string version = null) =>
+            new VisualStudioFilter(Channel: channel, Sku: sku, Expression: expression, Version: version);
     }
 }

--- a/src/VisualStudio.Tests/VisualStudioVersionTests.cs
+++ b/src/VisualStudio.Tests/VisualStudioVersionTests.cs
@@ -1,0 +1,29 @@
+using Xunit;
+
+namespace Devlooped.Tests
+{
+    public class VisualStudioVersionTests
+    {
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", null)]
+        [InlineData("18", "18")]
+        [InlineData("18.7", "18")]
+        [InlineData("18.7.3", "18")]
+        [InlineData("17.14.16", "17")]
+        public void when_getting_major_then_returns_major_component(string version, string expected) =>
+            Assert.Equal(expected, VisualStudioVersion.GetMajor(version));
+
+        [Theory]
+        [InlineData("18.7.3", null, true)]
+        [InlineData("18.7.3", "", true)]
+        [InlineData("18.7.3", "18", true)]
+        [InlineData("18.7.3", "18.7", true)]
+        [InlineData("18.7.3", "18.7.3", true)]
+        [InlineData("18.8.0", "18.7", false)]
+        [InlineData("17.14.16", "18", false)]
+        [InlineData(null, "18.7", false)]
+        public void when_matching_then_uses_semantic_prefix(string product, string requested, bool expected) =>
+            Assert.Equal(expected, VisualStudioVersion.Matches(product, requested));
+    }
+}

--- a/src/VisualStudio/CommandHelpers.cs
+++ b/src/VisualStudio/CommandHelpers.cs
@@ -13,14 +13,16 @@ static class CommandHelpers
         Option<string> skuOption,
         Option<string> filterOption = null,
         Option<bool> firstOption = null,
-        Option<bool> allOption = null)
+        Option<bool> allOption = null,
+        Option<string> versionOption = null)
     {
         return new VisualStudioFilter(
             Channel: channelOptions.GetChannel(parse),
             Sku: SharedOptions.ParseSku(parse.GetValue(skuOption)),
             Expression: filterOption != null ? parse.GetValue(filterOption) : null,
             First: firstOption != null && parse.GetValue(firstOption),
-            All: allOption != null && parse.GetValue(allOption));
+            All: allOption != null && parse.GetValue(allOption),
+            Version: versionOption != null ? parse.GetValue(versionOption) : null);
     }
 
     public static string[] GetWorkloadIds(ParseResult parse, Option<string[]> option)

--- a/src/VisualStudio/Commands/InstallCommand.cs
+++ b/src/VisualStudio/Commands/InstallCommand.cs
@@ -14,6 +14,7 @@ class InstallCommand : Command
     readonly Option<string> skuOption;
     readonly Option<string> filterOption;
     readonly Option<string> nicknameOption;
+    readonly Option<string> versionOption;
     readonly Option<string[]> addOption = new("--add")
     {
         Description = "A workload ID",
@@ -28,10 +29,12 @@ class InstallCommand : Command
         skuOption = SharedOptions.SkuOption();
         filterOption = SharedOptions.FilterOption();
         nicknameOption = SharedOptions.NicknameOption();
+        versionOption = SharedOptions.VersionOption("Install");
 
         Options.Add(skuOption);
         Options.Add(filterOption);
         Options.Add(nicknameOption);
+        Options.Add(versionOption);
         Options.Add(addOption);
 
         TreatUnmatchedTokensAsErrors = false;
@@ -48,6 +51,7 @@ class InstallCommand : Command
         var channel = channelOptions.GetChannel(parse);
         var sku = SharedOptions.ParseSku(parse.GetValue(skuOption)) ?? Sku.Community;
         var nickname = parse.GetValue(nicknameOption);
+        var version = parse.GetValue(versionOption);
         var workloads = CommandHelpers.GetWorkloadIds(parse, addOption);
         var extra = parse.UnmatchedTokens;
 
@@ -65,7 +69,7 @@ class InstallCommand : Command
 
         args.AddRange(extra);
 
-        var vs = await installerService.GetLatestMajorAsync();
+        var vs = VisualStudioVersion.GetMajor(version) ?? await installerService.GetLatestMajorAsync();
         var installBase = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
             "Microsoft Visual Studio",

--- a/src/VisualStudio/Commands/RunCommand.cs
+++ b/src/VisualStudio/Commands/RunCommand.cs
@@ -23,10 +23,7 @@ class RunCommand : Command
     {
         Description = "If more than one instance matches the criteria, run the first one sorted by descending build version.",
     };
-    readonly Option<string> versionOption = new("--version", "-v")
-    {
-        Description = "Run specific (semantic) version, such as 18.7 or 18.7.3",
-    };
+    readonly Option<string> versionOption;
     readonly Option<bool> waitOption = new("--wait", "-w")
     {
         Description = "Wait for the started Visual Studio to exit.",
@@ -58,6 +55,7 @@ class RunCommand : Command
         skuOption = SharedOptions.SkuOption();
         filterOption = SharedOptions.FilterOption();
         experimentalOption = SharedOptions.ExperimentalOption("run");
+        versionOption = SharedOptions.VersionOption("Run");
 
         Options.Add(skuOption);
         Options.Add(filterOption);
@@ -90,12 +88,11 @@ class RunCommand : Command
             : (bool?)null;
 
         var id = parse.GetValue(idOption);
-        var version = parse.GetValue(versionOption);
         var first = parse.GetValue(firstOption);
         var wait = parse.GetValue(waitOption);
         var disableNodeReuse = parse.GetValue(nodeReuseOption);
         var isExperimental = parse.GetValue(experimentalOption);
-        var filter = CommandHelpers.GetFilter(parse, channelOptions, skuOption, filterOption, firstOption);
+        var filter = CommandHelpers.GetFilter(parse, channelOptions, skuOption, filterOption, firstOption, versionOption: versionOption);
 
         var devenv = settings.Get("devenv");
         if (!string.IsNullOrEmpty(devenv))
@@ -118,13 +115,7 @@ class RunCommand : Command
             .OrderByDescending(i => i.Catalog.BuildVersion);
 
         if (!string.IsNullOrEmpty(id))
-        {
             instances = instances.Where(i => i.InstanceId.Equals(id, StringComparison.OrdinalIgnoreCase));
-        }
-        else if (version != null)
-        {
-            instances = instances.Where(i => i.Catalog.ProductSemanticVersion.StartsWith(version));
-        }
 
         var matches = instances.ToArray();
         if (matches.Length == 1 || (matches.Length > 0 && first))

--- a/src/VisualStudio/Commands/UpdateCommand.cs
+++ b/src/VisualStudio/Commands/UpdateCommand.cs
@@ -16,6 +16,7 @@ class UpdateCommand : Command
     readonly Option<string> filterOption;
     readonly Option<bool> firstOption;
     readonly Option<bool> allOption;
+    readonly Option<string> versionOption;
 
     public UpdateCommand(WhereService whereService, InstallerService installerService)
         : base(Commands.Update, "Updates an installation of Visual Studio.")
@@ -28,11 +29,13 @@ class UpdateCommand : Command
         filterOption = SharedOptions.FilterOption();
         firstOption = SharedOptions.FirstOption("Update");
         allOption = SharedOptions.AllOption("Update");
+        versionOption = SharedOptions.VersionOption("Update");
 
         Options.Add(skuOption);
         Options.Add(filterOption);
         Options.Add(firstOption);
         Options.Add(allOption);
+        Options.Add(versionOption);
 
         TreatUnmatchedTokensAsErrors = false;
 
@@ -45,7 +48,7 @@ class UpdateCommand : Command
 
     async Task ExecuteAsync(ParseResult parse, TextWriter output)
     {
-        var filter = CommandHelpers.GetFilter(parse, channelOptions, skuOption, filterOption, firstOption, allOption);
+        var filter = CommandHelpers.GetFilter(parse, channelOptions, skuOption, filterOption, firstOption, allOption, versionOption);
         var all = parse.GetValue(allOption);
         var extraArgs = parse.UnmatchedTokens.ToList();
 

--- a/src/VisualStudio/Docs/install.md
+++ b/src/VisualStudio/Docs/install.md
@@ -27,5 +27,11 @@ Examples:
 # Install VS community with the .NET Core, ASP.NET and Azure workloads, 
 # shows installation progress and waits for it to finish before returning
 > dnx vs -- install +core +web +azure
+
+# Install VS 18 Enterprise
+> dnx vs -- install -v:18 -sku:ent
+
+# Install the latest VS 17 (2022) Community
+> dnx vs -- install --version 17
 ```
 <!-- EXAMPLES_END -->

--- a/src/VisualStudio/Docs/update.md
+++ b/src/VisualStudio/Docs/update.md
@@ -7,3 +7,15 @@
 ```
 
 {Options}
+
+Examples:
+
+<!-- EXAMPLES_BEGIN -->
+```
+# Update the installed VS 18.7 instance
+> dnx vs -- update -v:18.7
+
+# Update all matching VS 17 instances
+> dnx vs -- update --version 17 --all
+```
+<!-- EXAMPLES_END -->

--- a/src/VisualStudio/InstallerService.cs
+++ b/src/VisualStudio/InstallerService.cs
@@ -67,7 +67,7 @@ namespace Devlooped
             if (int.TryParse(vs, out var major) && major >= 17)
                 args = args.Select(arg => arg == "Microsoft.VisualStudio.Workload.NetCoreTools" ? "Microsoft.NetCore.Component.DevelopmentTools" : arg);
 
-            return RunAsync(command, $"https://aka.ms/vs/{vs}/{MapChannel(channel)}", sku, args, output);
+            return RunAsync(command, $"https://aka.ms/vs/{vs}/{MapChannel(vs, channel)}", sku, args, output);
         }
 
         async Task RunAsync(string command, string channelUri, Sku? sku, IEnumerable<string> args, TextWriter output)
@@ -96,12 +96,16 @@ namespace Devlooped
             process.WaitForExit();
         }
 
-        string MapChannel(Channel? channel)
-            => channel switch
+        string MapChannel(string vs, Channel? channel)
+            => (channel, vs) switch
             {
-                Channel.Insiders => "insiders",
-                Channel.IntPreview => "intpreview",
-                Channel.Main => "int.main",
+                (Channel.Insiders, "15" or "16" or "17") => "pre",
+                (Channel.Insiders, _) => "insiders",
+                (Channel.IntPreview, _) => "intpreview",
+                (Channel.Main, _) => "int.main",
+                // VS 2017-2022 used "release" for the current/stable channel.
+                // VS 2026+ uses "stable".
+                (_, "15" or "16" or "17") => "release",
                 // Stable is the default; Channel.Stable and null both map here.
                 // "release" is accepted on the CLI as a hidden alias for Stable.
                 _ => "stable"

--- a/src/VisualStudio/Options/SharedOptions.cs
+++ b/src/VisualStudio/Options/SharedOptions.cs
@@ -57,6 +57,12 @@ static class SharedOptions
             Description = "Expression to filter VS instances. E.g. `x => x.InstanceId = '123'`",
         };
 
+    public static Option<string> VersionOption(string verb) =>
+        new("--version", "-v")
+        {
+            Description = $"{verb} specific (semantic) version, such as 18.7 or 18.7.3",
+        };
+
     public static Option<bool> FirstOption(string verb) =>
         new("--first")
         {
@@ -142,14 +148,16 @@ static class SharedOptions
         Option<string> sku,
         Option<string> filter = null,
         Option<bool> first = null,
-        Option<bool> all = null)
+        Option<bool> all = null,
+        Option<string> version = null)
     {
         return new VisualStudioFilter(
             Channel: channel.GetChannel(parse),
             Sku: ParseSku(parse.GetValue(sku)),
             Expression: filter != null ? parse.GetValue(filter) : null,
             First: first != null && parse.GetValue(first),
-            All: all != null && parse.GetValue(all));
+            All: all != null && parse.GetValue(all),
+            Version: version != null ? parse.GetValue(version) : null);
     }
 
     public static Sku? ParseSku(string sku)

--- a/src/VisualStudio/VisualStudioFilter.cs
+++ b/src/VisualStudio/VisualStudioFilter.cs
@@ -8,4 +8,5 @@ record VisualStudioFilter(
     Sku? Sku = null,
     string Expression = null,
     bool First = false,
-    bool All = false);
+    bool All = false,
+    string Version = null);

--- a/src/VisualStudio/VisualStudioPredicateBuilder.cs
+++ b/src/VisualStudio/VisualStudioPredicateBuilder.cs
@@ -26,7 +26,11 @@ namespace Devlooped
             if (!string.IsNullOrEmpty(filter.Expression))
                 filterPredicate = await CSharpScript.EvaluateAsync<Func<VisualStudioInstance, bool>>(filter.Expression, scriptOptions);
 
-            return x => skuPredicate(x) && channelPredicate(x) && filterPredicate(x);
+            Func<VisualStudioInstance, bool> versionPredicate = _ => true;
+            if (!string.IsNullOrEmpty(filter.Version))
+                versionPredicate = x => VisualStudioVersion.Matches(x.Catalog?.ProductSemanticVersion, filter.Version);
+
+            return x => skuPredicate(x) && channelPredicate(x) && filterPredicate(x) && versionPredicate(x);
         }
     }
 }

--- a/src/VisualStudio/VisualStudioVersion.cs
+++ b/src/VisualStudio/VisualStudioVersion.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace Devlooped;
+
+/// <summary>
+/// Helpers for the shared <c>--version</c>/<c>-v</c> Visual Studio version filter.
+/// </summary>
+static class VisualStudioVersion
+{
+    public static string GetMajor(string version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+            return null;
+
+        var dot = version.IndexOf('.');
+        return dot < 0 ? version : version[..dot];
+    }
+
+    public static bool Matches(string productSemanticVersion, string requested)
+    {
+        if (string.IsNullOrEmpty(requested))
+            return true;
+
+        return !string.IsNullOrEmpty(productSemanticVersion) &&
+            productSemanticVersion.StartsWith(requested, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/VisualStudio/readme.md
+++ b/src/VisualStudio/readme.md
@@ -91,6 +91,7 @@ Usage: dnx vs -- install [options]
 | `sku` | Edition, one of `e\|ent\|enterprise`, `p\|pro\|professional`, `c\|com\|community`, `b\|build\|buildtools` or `t\|test\|testagent` |
 | `filter` | Expression to filter VS instances. E.g. `x => x.InstanceId = '123'` |
 | `nick\|nickname` | Optional nickname to use |
+| `v\|version` | Install specific (semantic) version, such as 18.7 or 18.7.3 |
 | `add` | A workload ID |
 
 
@@ -113,6 +114,12 @@ Examples:
 # Install VS community with the .NET Core, ASP.NET and Azure workloads, 
 # shows installation progress and waits for it to finish before returning
 > dnx vs -- install +core +web +azure
+
+# Install VS 18 Enterprise
+> dnx vs -- install -v:18 -sku:ent
+
+# Install the latest VS 17 (2022) Community
+> dnx vs -- install --version 17
 ```
 <!-- EXAMPLES_END -->
 
@@ -263,7 +270,20 @@ Usage: dnx vs -- update [options]
 | `filter` | Expression to filter VS instances. E.g. `x => x.InstanceId = '123'` |
 | `first` | Update first matching instance. |
 | `all` | Update all instances. |
+| `v\|version` | Update specific (semantic) version, such as 18.7 or 18.7.3 |
 
+
+Examples:
+
+<!-- EXAMPLES_BEGIN -->
+```
+# Update the installed VS 18.7 instance
+> dnx vs -- update -v:18.7
+
+# Update all matching VS 17 instances
+> dnx vs -- update --version 17 --all
+```
+<!-- EXAMPLES_END -->
 
 ## where
 


### PR DESCRIPTION
`run` already accepted `--version` / `-v` to target a specific installed Visual Studio. `install` and `update` now take the same option so you can manage specific VS versions from one flag.

- **install**: uses the major from `--version` (`18.7` → `18`) to pick the aka.ms bootstrapper (`/vs/18/stable/`, `/vs/17/release/`, etc.)
- **update**: filters installed instances by semantic version prefix, same as `run`
- Shared `VisualStudioFilter.Version` so instance selection is consistent
- Channel mapping is major-aware: VS 2017-2022 use `release`/`pre`, VS 2026+ use `stable`/`insiders`

Examples:

```
dnx vs -- install -v:18 -sku:ent
dnx vs -- install --version 17
dnx vs -- update -v:18.7
```